### PR TITLE
Update plugin settings for list view

### DIFF
--- a/Configuration/FlexForms/flexform_profile_list.xml
+++ b/Configuration/FlexForms/flexform_profile_list.xml
@@ -79,7 +79,7 @@
                                 <renderType>checkboxToggle</renderType>
                                 <items>
                                     <numIndex index="0" type="array">
-                                        <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.paginationEnabled.items.0.label</numIndex>>
+                                        <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.paginationEnabled.items.0.label</numIndex>
                                         <labelChecked>Enabled</labelChecked>
                                         <labelUnchecked>Disabled</labelUnchecked>
                                     </numIndex>
@@ -87,6 +87,64 @@
                             </config>
                         </TCEforms>
                     </settings.paginationEnabled>
+                    <settings.pagination.resultsPerPage>
+                        <TCEforms>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.resultsPerPage.label</label>
+                            <config>
+                                <type>select</type>
+                                <renderType>selectSingle</renderType>
+                                <items>
+                                    <numIndex index="0" type="array">
+                                        <numIndex index="0">12</numIndex>
+                                        <numIndex index="1">12</numIndex>
+                                    </numIndex>
+                                    <numIndex index="1" type="array">
+                                        <numIndex index="0">24</numIndex>
+                                        <numIndex index="1">24</numIndex>
+                                    </numIndex>
+                                    <numIndex index="2" type="array">
+                                        <numIndex index="0">36</numIndex>
+                                        <numIndex index="1">36</numIndex>
+                                    </numIndex>
+                                    <numIndex index="3" type="array">
+                                        <numIndex index="0">48</numIndex>
+                                        <numIndex index="1">48</numIndex>
+                                    </numIndex>
+                                </items>
+                            </config>
+                        </TCEforms>
+                    </settings.pagination.resultsPerPage>
+                    <settings.pagination.numberOfLinks>
+                        <TCEforms>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.numberOfLinks.label</label>
+                            <config>
+                                <type>select</type>
+                                <renderType>selectSingle</renderType>
+                                <items>
+                                    <numIndex index="0" type="array">
+                                        <numIndex index="0">3</numIndex>
+                                        <numIndex index="1">3</numIndex>
+                                    </numIndex>
+                                    <numIndex index="1" type="array">
+                                        <numIndex index="0">5</numIndex>
+                                        <numIndex index="1">5</numIndex>
+                                    </numIndex>
+                                    <numIndex index="2" type="array">
+                                        <numIndex index="0">7</numIndex>
+                                        <numIndex index="1">7</numIndex>
+                                    </numIndex>
+                                    <numIndex index="3" type="array">
+                                        <numIndex index="0">9</numIndex>
+                                        <numIndex index="1">9</numIndex>
+                                    </numIndex>
+                                    <numIndex index="4" type="array">
+                                        <numIndex index="0">11</numIndex>
+                                        <numIndex index="1">11</numIndex>
+                                    </numIndex>
+                                </items>
+                            </config>
+                        </TCEforms>
+                    </settings.pagination.numberOfLinks>
                     <settings.demand.profileList>
                         <TCEforms>
                             <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.profileList.label</label>

--- a/Configuration/FlexForms/flexform_profile_list.xml
+++ b/Configuration/FlexForms/flexform_profile_list.xml
@@ -91,26 +91,8 @@
                         <TCEforms>
                             <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.resultsPerPage.label</label>
                             <config>
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <items>
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">12</numIndex>
-                                        <numIndex index="1">12</numIndex>
-                                    </numIndex>
-                                    <numIndex index="1" type="array">
-                                        <numIndex index="0">24</numIndex>
-                                        <numIndex index="1">24</numIndex>
-                                    </numIndex>
-                                    <numIndex index="2" type="array">
-                                        <numIndex index="0">36</numIndex>
-                                        <numIndex index="1">36</numIndex>
-                                    </numIndex>
-                                    <numIndex index="3" type="array">
-                                        <numIndex index="0">48</numIndex>
-                                        <numIndex index="1">48</numIndex>
-                                    </numIndex>
-                                </items>
+                                <type>input</type>
+                                <size>2</size>
                             </config>
                         </TCEforms>
                     </settings.pagination.resultsPerPage>
@@ -118,30 +100,8 @@
                         <TCEforms>
                             <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.numberOfLinks.label</label>
                             <config>
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <items>
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">3</numIndex>
-                                        <numIndex index="1">3</numIndex>
-                                    </numIndex>
-                                    <numIndex index="1" type="array">
-                                        <numIndex index="0">5</numIndex>
-                                        <numIndex index="1">5</numIndex>
-                                    </numIndex>
-                                    <numIndex index="2" type="array">
-                                        <numIndex index="0">7</numIndex>
-                                        <numIndex index="1">7</numIndex>
-                                    </numIndex>
-                                    <numIndex index="3" type="array">
-                                        <numIndex index="0">9</numIndex>
-                                        <numIndex index="1">9</numIndex>
-                                    </numIndex>
-                                    <numIndex index="4" type="array">
-                                        <numIndex index="0">11</numIndex>
-                                        <numIndex index="1">11</numIndex>
-                                    </numIndex>
-                                </items>
+                                <type>input</type>
+                                <size>2</size>
                             </config>
                         </TCEforms>
                     </settings.pagination.numberOfLinks>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -54,7 +54,7 @@
                 <source>Last Name</source>
             </trans-unit>
             <trans-unit id="flexform.el.sortBy.label">
-                <source>Sort By (this setting only works when "Group By" is set at "No grouping")</source>
+                <source>Sort By (will be ignored if grouping is active)</source>
             </trans-unit>
             <trans-unit id="flexform.el.sortBy.items.none">
                 <source>No sorting</source>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -78,10 +78,10 @@
                 <source>Pagination</source>
             </trans-unit>
             <trans-unit id="flexform.el.resultsPerPage.label">
-                <source>Results per Page (only works when Pagination is set at Enabled [1])</source>
+                <source>Results per Page</source>
             </trans-unit>
             <trans-unit id="flexform.el.numberOfLinks.label">
-                <source>Number of Links (only works when Pagination is set at Enabled [1])</source>
+                <source>Number of Links</source>
             </trans-unit>
             <trans-unit id="flexform.el.paginationEnabled.items.0.label">
                 <source>Enabled</source>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -42,7 +42,7 @@
                 <source>List Page</source>
             </trans-unit>
             <trans-unit id="flexform.el.groupBy.label">
-                <source>Group By (if set, this setting will override "Sort By" setting)</source>
+                <source>Group By (this setting will override the sorting settings)</source>
             </trans-unit>
             <trans-unit id="flexform.el.groupBy.items.none">
                 <source>No grouping</source>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -42,7 +42,7 @@
                 <source>List Page</source>
             </trans-unit>
             <trans-unit id="flexform.el.groupBy.label">
-                <source>Group By</source>
+                <source>Group By (if set, this setting will override "Sort By" setting)</source>
             </trans-unit>
             <trans-unit id="flexform.el.groupBy.items.none">
                 <source>No grouping</source>
@@ -54,7 +54,7 @@
                 <source>Last Name</source>
             </trans-unit>
             <trans-unit id="flexform.el.sortBy.label">
-                <source>Sort By</source>
+                <source>Sort By (this setting only works when "Group By" is set at "No grouping")</source>
             </trans-unit>
             <trans-unit id="flexform.el.sortBy.items.none">
                 <source>No sorting</source>
@@ -76,6 +76,12 @@
             </trans-unit>
             <trans-unit id="flexform.el.paginationEnabled.label">
                 <source>Pagination</source>
+            </trans-unit>
+            <trans-unit id="flexform.el.resultsPerPage.label">
+                <source>Results per Page (only works when Pagination is set at Enabled [1])</source>
+            </trans-unit>
+            <trans-unit id="flexform.el.numberOfLinks.label">
+                <source>Number of Links (only works when Pagination is set at Enabled [1])</source>
             </trans-unit>
             <trans-unit id="flexform.el.paginationEnabled.items.0.label">
                 <source>Enabled</source>


### PR DESCRIPTION
- Adjust labels in academicpersons_list plugin
- Add options "Results per Page" and "Number of Links" to plugin, they works only when option "Pagination" is enabled

![Screenshot from 2024-01-15 16-26-39](https://github.com/fgtclb/academic-persons/assets/156296474/ef45b525-4659-47e9-99ef-2c2f81bc7f3c)
