### PR TITLE
Draft: Set default constants for pagination

### DIFF
--- a/Classes/Controller/ProfileController.php
+++ b/Classes/Controller/ProfileController.php
@@ -84,7 +84,7 @@ final class ProfileController extends ActionController
         if (($this->settings['paginationEnabled'] ?? null) === '1') {
             if (isset($this->settings['pagination']['resultsPerPage']) && (int)($this->settings['pagination']['resultsPerPage']) > 0) {
                 $resultsPerPage = (int)($this->settings['pagination']['resultsPerPage']);
-            } elseif (isset($ts_resultsPerPage) && $ts_resultsPerPage > 0) {
+            } elseif ($ts_resultsPerPage > 0) {
                 $resultsPerPage = $ts_resultsPerPage;
             } else {
                 $resultsPerPage = 12;
@@ -92,7 +92,7 @@ final class ProfileController extends ActionController
 
             if (isset($this->settings['pagination']['numberOfLinks']) && (int)($this->settings['pagination']['numberOfLinks']) > 0) {
                 $numberOfPaginationLinks = (int)($this->settings['pagination']['numberOfLinks']);
-            } elseif (isset($ts_numberOfLinks) && $ts_numberOfLinks > 0) {
+            } elseif ($ts_numberOfLinks > 0) {
                 $numberOfPaginationLinks = $ts_numberOfLinks;
             } else {
                 $numberOfPaginationLinks = 5;

--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -6,8 +6,10 @@ plugin.tx_academicpersons {
     sortByDirection = asc
   }
   pagination {
-    resultsPerPage = 1
-    numberOfLinks = 5
+    # cat=plugin.tx_academicpersons//pagination.resultsPerPage; type=int+; label= Number of results display in each paginated page
+    resultsPerPage =
+    # cat=plugin.tx_academicpersons//pagination.numberOfLinks; type=int+; label= Number of links display in pagination
+    numberOfLinks =
   }
   view {
     templateRootPath = EXT:academic_persons/Resources/Private/Templates/


### PR DESCRIPTION
- Add constants for setting values of pagination
- Use typoscript constants as default values. Flexform values are considered first, if they are not set, typoscript constants will be used. If typoscript constants are not set either, the default values are 12 for resultsPerPage and 5 for numberOfLinks

![Screenshot from 2024-01-24 13-06-22](https://github.com/fgtclb/academic-persons/assets/156296474/8cfe92bc-92d4-4e25-9cec-b22394831714)
