### PR TITLE
Update TCA for profile, profile information and address records

### DIFF
--- a/Configuration/TCA/tx_academicpersons_domain_model_address.php
+++ b/Configuration/TCA/tx_academicpersons_domain_model_address.php
@@ -19,6 +19,7 @@ return [
         'tstamp' => 'tstamp',
         'title' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_address.ctrl.label',
         'delete' => 'deleted',
+        'hideTable' => true,
         'origUid' => 't3_origuid',
         'transOrigPointerField' => 'l10n_parent',
         'transOrigDiffSourceField' => 'l10n_diffsource',
@@ -206,48 +207,48 @@ return [
     'palettes' => [
         'general' => [
             'label' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.general',
-            'showitem' => '
-                type,
-                --linebreak--,
-                employee_type,
-                --linebreak--,
-                organisational_level_1,
-                organisational_level_2,
-                organisational_level_3,
-            ',
+            'showitem' => implode(',', [
+                'type',
+                '--linebreak--',
+                'employee_type',
+                '--linebreak--',
+                'organisational_level_1',
+                'organisational_level_2',
+                'organisational_level_3',
+            ]),
         ],
         'address' => [
-            'showitem' => '
-                street,
-                street_number,
-                --linebreak--,
-                additional,
-                --linebreak--,
-                zip,
-                city,
-                --linebreak--,
-                state,
-                --linebreak--,
-                country
-            ',
+            'showitem' => implode(',', [
+                'street',
+                'street_number',
+                '--linebreak--',
+                'additional',
+                '--linebreak--',
+                'zip',
+                'city',
+                '--linebreak--',
+                'state',
+                '--linebreak--',
+                'country',
+            ]),
         ],
         'language' => [
-            'showitem' => '
-                sys_language_uid;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:sys_language_uid_formlabel,
-                l10n_parent,
-            ',
+            'showitem' => implode(',', [
+                'sys_language_uid;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:sys_language_uid_formlabel',
+                'l10n_parent',
+            ]),
         ],
     ],
     'types' => [
         '1' => [
-            'showitem' => '
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
-                    --palette--;;general,
-                    --palette--;;address,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
-                    --palette--;;language,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended,
-            ',
+            'showitem' => implode(',', [
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general',
+                    '--palette--;;general',
+                    '--palette--;;address',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language',
+                    '--palette--;;language',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended',
+            ]),
         ],
     ],
 ];

--- a/Configuration/TCA/tx_academicpersons_domain_model_contract.php
+++ b/Configuration/TCA/tx_academicpersons_domain_model_contract.php
@@ -33,8 +33,10 @@ return [
     ],
     'columns' => [
         'hidden' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.visible',
+            'exclude' => true,
+            'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly',
             'config' => [
                 'type' => 'check',
                 'renderType' => 'checkboxToggle',
@@ -47,15 +49,16 @@ return [
             ],
         ],
         'sys_language_uid' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
+            'exclude' => true,
             'config' => [
                 'type' => 'language',
             ],
         ],
         'l10n_parent' => [
-            'displayCond' => 'FIELD:sys_language_uid:>:0',
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
+            'exclude' => true,
+            'displayCond' => 'FIELD:sys_language_uid:>:0',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
@@ -77,8 +80,6 @@ return [
         ],
         'profile' => [
             'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_contract.columns.profile.label',
-            'l10n_display' => 'defaultAsReadonly',
-            'l10n_mode' => 'exclude',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
@@ -92,8 +93,8 @@ return [
         ],
         'employee_type' => [
             'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_contract.columns.employee_type.label',
-            'l10n_display' => 'defaultAsReadonly',
             'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly',
             'config' => [
                 'type' => 'category',
                 'relationship' => 'oneToOne',
@@ -103,8 +104,8 @@ return [
         ],
         'organisational_level_1' => [
             'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_contract.columns.organisational_level_1.label',
-            'l10n_display' => 'defaultAsReadonly',
             'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly',
             'config' => [
                 'type' => 'category',
                 'relationship' => 'oneToOne',
@@ -114,8 +115,8 @@ return [
         ],
         'organisational_level_2' => [
             'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_contract.columns.organisational_level_2.label',
-            'l10n_display' => 'defaultAsReadonly',
             'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly',
             'config' => [
                 'type' => 'category',
                 'relationship' => 'oneToOne',
@@ -125,8 +126,8 @@ return [
         ],
         'organisational_level_3' => [
             'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_contract.columns.organisational_level_3.label',
-            'l10n_display' => 'defaultAsReadonly',
             'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly',
             'config' => [
                 'type' => 'category',
                 'relationship' => 'oneToOne',

--- a/Configuration/TCA/tx_academicpersons_domain_model_contract.php
+++ b/Configuration/TCA/tx_academicpersons_domain_model_contract.php
@@ -57,7 +57,6 @@ return [
         ],
         'l10n_parent' => [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
-            'exclude' => true,
             'displayCond' => 'FIELD:sys_language_uid:>:0',
             'config' => [
                 'type' => 'select',

--- a/Configuration/TCA/tx_academicpersons_domain_model_profile.php
+++ b/Configuration/TCA/tx_academicpersons_domain_model_profile.php
@@ -167,7 +167,6 @@ return [
         ],
         'l10n_parent' => [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
-            'exclude' => true,
             'displayCond' => 'FIELD:sys_language_uid:>:0',
             'config' => [
                 'type' => 'select',

--- a/Configuration/TCA/tx_academicpersons_domain_model_profile.php
+++ b/Configuration/TCA/tx_academicpersons_domain_model_profile.php
@@ -555,7 +555,11 @@ return [
     ],
 ];
 
-function getProfileInformationConfig($type): array
+/**
+ * @param string $type
+ * @return array<string, mixed>
+ */
+function getProfileInformationConfig(string $type): array
 {
     return [
         'type' => 'inline',

--- a/Configuration/TCA/tx_academicpersons_domain_model_profile.php
+++ b/Configuration/TCA/tx_academicpersons_domain_model_profile.php
@@ -9,15 +9,17 @@ declare(strict_types=1);
  * LICENSE file that was distributed with this source code.
  */
 
+$lPath = 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.';
+
 return [
     'ctrl' => [
-        'label' => 'first_name',
-        'label_alt' => 'middle_name,last_name',
+        'label' => 'last_name',
+        'label_alt' => 'first_name',
         'label_alt_force' => true,
         'default_sortby' => 'last_name',
         'crdate' => 'crdate',
         'tstamp' => 'tstamp',
-        'title' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.ctrl.label',
+        'title' => $lPath . 'ctrl.label',
         'delete' => 'deleted',
         'origUid' => 't3_origuid',
         'transOrigPointerField' => 'l10n_parent',
@@ -37,8 +39,10 @@ return [
     ],
     'columns' => [
         'hidden' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.visible',
+            'exclude' => true,
+            'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly',
             'config' => [
                 'type' => 'check',
                 'renderType' => 'checkboxToggle',
@@ -51,20 +55,22 @@ return [
             ],
         ],
         'starttime' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.starttime',
+            'exclude' => true,
+            'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly',
             'config' => [
                 'type' => 'input',
                 'renderType' => 'inputDateTime',
                 'eval' => 'datetime,int',
                 'default' => 0,
             ],
-            'l10n_mode' => 'exclude',
-            'l10n_display' => 'defaultAsReadonly',
         ],
         'endtime' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.endtime',
+            'exclude' => true,
+            'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly',
             'config' => [
                 'type' => 'input',
                 'renderType' => 'inputDateTime',
@@ -74,12 +80,12 @@ return [
                     'upper' => mktime(0, 0, 0, 1, 1, 2038),
                 ],
             ],
-            'l10n_mode' => 'exclude',
-            'l10n_display' => 'defaultAsReadonly',
         ],
         'fe_group' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.fe_group',
+            'exclude' => true,
+            'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectMultipleSideBySide',
@@ -104,15 +110,16 @@ return [
             ],
         ],
         'sys_language_uid' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
+            'exclude' => true,
             'config' => [
                 'type' => 'language',
             ],
         ],
         'l10n_parent' => [
-            'displayCond' => 'FIELD:sys_language_uid:>:0',
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
+            'exclude' => true,
+            'displayCond' => 'FIELD:sys_language_uid:>:0',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
@@ -132,28 +139,53 @@ return [
                 'type' => 'passthrough',
             ],
         ],
-        'gender' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.gender.label',
-            'l10n_display' => 'defaultAsReadonly',
+        'slug' => [
+            'label' => $lPath . 'columns.slug.label',
+            'exclude' => true,
             'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly',
+            'config' => [
+                'type' => 'slug',
+                'size' => 50,
+                'generatorOptions' => [
+                    'fields' => [
+                        'first_name',
+                        'last_name',
+                        'uid',
+                    ],
+                    'fieldSeparator' => '-',
+                    'prefixParentPageSlug' => false,
+                    'replacements' => [
+                        '/' => '',
+                    ],
+                ],
+                'fallbackCharacter' => '-',
+                'eval' => 'uniqueInPid',
+                'default' => '',
+            ],
+        ],
+        'gender' => [
+            'label' => $lPath . 'columns.gender.label',
+            'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'items' => [
                     [
-                        'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.gender.items.none',
+                        $lPath . 'columns.gender.items.none',
                         '',
                     ],
                     [
-                        'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.gender.items.mr',
+                        $lPath . 'columns.gender.items.mr',
                         'mr',
                     ],
                     [
-                        'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.gender.items.ms',
+                        $lPath . 'columns.gender.items.ms',
                         'ms',
                     ],
                     [
-                        'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.gender.items.diverse',
+                        $lPath . 'columns.gender.items.diverse',
                         'diverse',
                     ],
                 ],
@@ -161,8 +193,7 @@ return [
             ],
         ],
         'title' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.title.label',
-            'exclude' => true,
+            'label' => $lPath . 'columns.title.label',
             'config' => [
                 'type' => 'input',
                 'size' => 50,
@@ -170,7 +201,9 @@ return [
             ],
         ],
         'first_name' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.first_name.label',
+            'label' => $lPath . 'columns.first_name.label',
+            'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly',
             'config' => [
                 'type' => 'input',
                 'size' => 50,
@@ -179,16 +212,20 @@ return [
             ],
         ],
         'first_name_alpha' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.first_name_alpha.label',
+            'label' => $lPath . 'columns.first_name_alpha.label',
+            'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly',
             'config' => [
                 'type' => 'input',
-                'size' => 5,
-                'max' => 1,
+                'readOnly' => true,
+                'size' => 2,
+                'max' => 2,
             ],
         ],
         'middle_name' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.middle_name.label',
-            'exclude' => true,
+            'label' => $lPath . 'columns.middle_name.label',
+            'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly',
             'config' => [
                 'type' => 'input',
                 'size' => 50,
@@ -196,7 +233,9 @@ return [
             ],
         ],
         'last_name' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.last_name.label',
+            'label' => $lPath . 'columns.last_name.label',
+            'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly',
             'config' => [
                 'type' => 'input',
                 'size' => 50,
@@ -205,15 +244,19 @@ return [
             ],
         ],
         'last_name_alpha' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.last_name_alpha.label',
+            'label' => $lPath . 'columns.last_name_alpha.label',
+            'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly',
             'config' => [
                 'type' => 'input',
-                'size' => 5,
-                'max' => 1,
+                'readOnly' => true,
+                'size' => 2,
+                'max' => 2,
             ],
         ],
         'image' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.image.label',
+            'label' => $lPath . 'columns.image.label',
+            'l10n_mode' => 'exclude',
             'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig(
                 'image',
                 [
@@ -267,29 +310,8 @@ return [
                 $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']
             ),
         ],
-        'slug' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.slug.label',
-            'config' => [
-                'type' => 'slug',
-                'size' => 50,
-                'generatorOptions' => [
-                    'fields' => [
-                        'first_name',
-                        'last_name',
-                    ],
-                    'fieldSeparator' => '-',
-                    'prefixParentPageSlug' => false,
-                    'replacements' => [
-                        '/' => '',
-                    ],
-                ],
-                'fallbackCharacter' => '-',
-                'eval' => 'uniqueInPid',
-                'default' => '',
-            ],
-        ],
         'contracts' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.contracts.label',
+            'label' => $lPath . 'columns.contracts.label',
             'exclude' => true,
             'config' => [
                 'type' => 'inline',
@@ -303,8 +325,8 @@ return [
                     'suppressCombinationWarning' => false,
                     'useSortable' => true,
                     'showPossibleLocalizationRecords' => true,
-                    'showAllLocalizationLink' => false,
-                    'showSynchronizationLink' => false,
+                    'showAllLocalizationLink' => true,
+                    'showSynchronizationLink' => true,
                     'enabledControls' => [
                         'info' => true,
                         'new' => true,
@@ -326,8 +348,7 @@ return [
             ],
         ],
         'website_title' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.website_title.label',
-            'exclude' => true,
+            'label' => $lPath . 'columns.website_title.label',
             'config' => [
                 'type' => 'input',
                 'size' => 50,
@@ -335,8 +356,9 @@ return [
             ],
         ],
         'website' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.website.label',
-            'exclude' => true,
+            'label' => $lPath . 'columns.website.label',
+            'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly',
             'config' => [
                 'type' => 'input',
                 'size' => 50,
@@ -344,7 +366,7 @@ return [
             ],
         ],
         'teaching_area' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.teaching_area.label',
+            'label' => $lPath . 'columns.teaching_area.label',
             'exclude' => true,
             'config' => [
                 'type' => 'text',
@@ -353,7 +375,7 @@ return [
             ],
         ],
         'core_competences' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.core_competences.label',
+            'label' => $lPath . 'columns.core_competences.label',
             'exclude' => true,
             'config' => [
                 'type' => 'text',
@@ -361,57 +383,8 @@ return [
                 'richtextConfiguration' => 'profile',
             ],
         ],
-        'memberships' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.memberships.label',
-            'exclude' => true,
-            'config' => [
-                'type' => 'inline',
-                'appearance' => [
-                    'collapseAll' => true,
-                    'expandSingle' => false,
-                    'showNewRecordLink' => true,
-                    'newRecordLinkAddTitle' => true,
-                    'levelLinksPosition' => 'top',
-                    'useCombination' => false,
-                    'suppressCombinationWarning' => false,
-                    'useSortable' => true,
-                    'showPossibleLocalizationRecords' => true,
-                    'showAllLocalizationLink' => false,
-                    'showSynchronizationLink' => false,
-                    'enabledControls' => [
-                        'info' => true,
-                        'new' => true,
-                        'dragdrop' => true,
-                        'sort' => false,
-                        'hide' => true,
-                        'delete' => true,
-                        'localize' => true,
-                    ],
-                    'showPossibleRecordsSelector' => false,
-                    'fileUploadAllowed' => false,
-                    'fileByUrlAllowed' => false,
-                    'elementBrowserEnabled' => false,
-                ],
-                'enableCascadingDelete' => true,
-                'foreign_field' => 'profile',
-                'foreign_sortby' => 'sorting',
-                'foreign_table' => 'tx_academicpersons_domain_model_profile_information',
-                'foreign_match_fields' => [
-                    'type' => 'membership',
-                ],
-                'overrideChildTca' => [
-                    'columns' => [
-                        'type' => [
-                            'config' => [
-                                'default' => 'membership',
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ],
         'supervised_thesis' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.supervised_thesis.label',
+            'label' => $lPath . 'columns.supervised_thesis.label',
             'exclude' => true,
             'config' => [
                 'type' => 'text',
@@ -420,7 +393,7 @@ return [
             ],
         ],
         'supervised_doctoral_thesis' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.supervised_doctoral_thesis.label',
+            'label' => $lPath . 'columns.supervised_doctoral_thesis.label',
             'exclude' => true,
             'config' => [
                 'type' => 'text',
@@ -428,106 +401,8 @@ return [
                 'richtextConfiguration' => 'profile',
             ],
         ],
-        'vita' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.vita.label',
-            'exclude' => true,
-            'config' => [
-                'type' => 'inline',
-                'appearance' => [
-                    'collapseAll' => true,
-                    'expandSingle' => false,
-                    'showNewRecordLink' => true,
-                    'newRecordLinkAddTitle' => true,
-                    'levelLinksPosition' => 'top',
-                    'useCombination' => false,
-                    'suppressCombinationWarning' => false,
-                    'useSortable' => true,
-                    'showPossibleLocalizationRecords' => true,
-                    'showAllLocalizationLink' => false,
-                    'showSynchronizationLink' => false,
-                    'enabledControls' => [
-                        'info' => true,
-                        'new' => true,
-                        'dragdrop' => true,
-                        'sort' => false,
-                        'hide' => true,
-                        'delete' => true,
-                        'localize' => true,
-                    ],
-                    'showPossibleRecordsSelector' => false,
-                    'fileUploadAllowed' => false,
-                    'fileByUrlAllowed' => false,
-                    'elementBrowserEnabled' => false,
-                ],
-                'enableCascadingDelete' => true,
-                'foreign_field' => 'profile',
-                'foreign_sortby' => 'sorting',
-                'foreign_table' => 'tx_academicpersons_domain_model_profile_information',
-                'foreign_match_fields' => [
-                    'type' => 'curriculum_vitae',
-                ],
-                'overrideChildTca' => [
-                    'columns' => [
-                        'type' => [
-                            'config' => [
-                                'default' => 'curriculum_vitae',
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ],
-        'publications' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.publications.label',
-            'exclude' => true,
-            'config' => [
-                'type' => 'inline',
-                'appearance' => [
-                    'collapseAll' => true,
-                    'expandSingle' => false,
-                    'showNewRecordLink' => true,
-                    'newRecordLinkAddTitle' => true,
-                    'levelLinksPosition' => 'top',
-                    'useCombination' => false,
-                    'suppressCombinationWarning' => false,
-                    'useSortable' => true,
-                    'showPossibleLocalizationRecords' => true,
-                    'showAllLocalizationLink' => false,
-                    'showSynchronizationLink' => false,
-                    'enabledControls' => [
-                        'info' => true,
-                        'new' => true,
-                        'dragdrop' => true,
-                        'sort' => false,
-                        'hide' => true,
-                        'delete' => true,
-                        'localize' => true,
-                    ],
-                    'showPossibleRecordsSelector' => false,
-                    'fileUploadAllowed' => false,
-                    'fileByUrlAllowed' => false,
-                    'elementBrowserEnabled' => false,
-                ],
-                'enableCascadingDelete' => true,
-                'foreign_field' => 'profile',
-                'foreign_sortby' => 'sorting',
-                'foreign_table' => 'tx_academicpersons_domain_model_profile_information',
-                'foreign_match_fields' => [
-                    'type' => 'publication',
-                ],
-                'overrideChildTca' => [
-                    'columns' => [
-                        'type' => [
-                            'config' => [
-                                'default' => 'publication',
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ],
         'miscellaneous' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.miscellaneous.label',
+            'label' => $lPath . 'columns.miscellaneous.label',
             'exclude' => true,
             'config' => [
                 'type' => 'text',
@@ -536,7 +411,7 @@ return [
             ],
         ],
         'publications_link_title' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.publications_link_title.label',
+            'label' => $lPath . 'columns.publications_link_title.label',
             'exclude' => true,
             'config' => [
                 'type' => 'input',
@@ -545,7 +420,9 @@ return [
             ],
         ],
         'publications_link' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.publications_link.label',
+            'label' => $lPath . 'columns.publications_link.label',
+            'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly',
             'exclude' => true,
             'config' => [
                 'type' => 'input',
@@ -554,171 +431,175 @@ return [
             ],
         ],
         'cooperation' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.cooperation.label',
+            'label' => $lPath . 'columns.cooperation.label',
             'exclude' => true,
-            'config' => [
-                'type' => 'inline',
-                'appearance' => [
-                    'collapseAll' => true,
-                    'expandSingle' => false,
-                    'showNewRecordLink' => true,
-                    'newRecordLinkAddTitle' => true,
-                    'levelLinksPosition' => 'top',
-                    'useCombination' => false,
-                    'suppressCombinationWarning' => false,
-                    'useSortable' => true,
-                    'showPossibleLocalizationRecords' => true,
-                    'showAllLocalizationLink' => false,
-                    'showSynchronizationLink' => false,
-                    'enabledControls' => [
-                        'info' => true,
-                        'new' => true,
-                        'dragdrop' => true,
-                        'sort' => false,
-                        'hide' => true,
-                        'delete' => true,
-                        'localize' => true,
-                    ],
-                    'showPossibleRecordsSelector' => false,
-                    'fileUploadAllowed' => false,
-                    'fileByUrlAllowed' => false,
-                    'elementBrowserEnabled' => false,
-                ],
-                'enableCascadingDelete' => true,
-                'foreign_field' => 'profile',
-                'foreign_sortby' => 'sorting',
-                'foreign_table' => 'tx_academicpersons_domain_model_profile_information',
-                'foreign_match_fields' => [
-                    'type' => 'cooperation',
-                ],
-                'overrideChildTca' => [
-                    'columns' => [
-                        'type' => [
-                            'config' => [
-                                'default' => 'cooperation',
-                            ],
-                        ],
-                    ],
-                ],
-            ],
+            'config' => getProfileInformationConfig('cooperation'),
         ],
         'lectures' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.lectures.label',
+            'label' => $lPath . 'columns.lectures.label',
             'exclude' => true,
-            'config' => [
-                'type' => 'inline',
-                'appearance' => [
-                    'collapseAll' => true,
-                    'expandSingle' => false,
-                    'showNewRecordLink' => true,
-                    'newRecordLinkAddTitle' => true,
-                    'levelLinksPosition' => 'top',
-                    'useCombination' => false,
-                    'suppressCombinationWarning' => false,
-                    'useSortable' => true,
-                    'showPossibleLocalizationRecords' => true,
-                    'showAllLocalizationLink' => false,
-                    'showSynchronizationLink' => false,
-                    'enabledControls' => [
-                        'info' => true,
-                        'new' => true,
-                        'dragdrop' => true,
-                        'sort' => false,
-                        'hide' => true,
-                        'delete' => true,
-                        'localize' => true,
-                    ],
-                    'showPossibleRecordsSelector' => false,
-                    'fileUploadAllowed' => false,
-                    'fileByUrlAllowed' => false,
-                    'elementBrowserEnabled' => false,
-                ],
-                'enableCascadingDelete' => true,
-                'foreign_field' => 'profile',
-                'foreign_sortby' => 'sorting',
-                'foreign_table' => 'tx_academicpersons_domain_model_profile_information',
-                'foreign_match_fields' => [
-                    'type' => 'lecture',
-                ],
-                'overrideChildTca' => [
-                    'columns' => [
-                        'type' => [
-                            'config' => [
-                                'default' => 'lecture',
-                            ],
-                        ],
-                    ],
-                ],
-            ],
+            'config' => getProfileInformationConfig('lecture'),
+        ],
+        'memberships' => [
+            'label' => $lPath . 'columns.memberships.label',
+            'exclude' => true,
+            'config' => getProfileInformationConfig('membership'),
+        ],
+        'press_media' => [
+            'label' => $lPath . 'columns.press_media.label',
+            'exclude' => true,
+            'config' => getProfileInformationConfig('press_media'),
+        ],
+        'publications' => [
+            'label' => $lPath . 'columns.publications.label',
+            'exclude' => true,
+                'config' => getProfileInformationConfig('publication'),
+        ],
+        'scientific_research' => [
+            'label' => $lPath . 'columns.scientific_research.label',
+            'exclude' => true,
+            'config' => getProfileInformationConfig('scientific_research'),
+        ],
+        'vita' => [
+            'label' => $lPath . 'columns.vita.label',
+            'exclude' => true,
+            'config' => getProfileInformationConfig('curriculum_vitae'),
         ],
     ],
     'palettes' => [
         'name' => [
-            'showitem' => '
-                gender,
-                title,
-                --linebreak--,
-                first_name,
-                middle_name,
-                last_name,
-            ',
+            'showitem' => implode(',', [
+                'gender',
+                'title',
+                '--linebreak--',
+                'first_name',
+                'first_name_alpha',
+                '--linebreak--',
+                'middle_name',
+                '--linebreak--',
+                'last_name',
+                'last_name_alpha',
+            ]),
+        ],
+        'website' => [
+            'showitem' => implode(',', [
+                'website',
+                'website_title',
+            ]),
+        ],
+        'publications' => [
+            'showitem' => implode(',', [
+                'publications_link',
+                'publications_link_title',
+            ]),
         ],
         'slug' => [
-            'showitem' => '
-                slug,
-            ',
+            'showitem' => implode(',', [
+                'slug',
+            ]),
         ],
         'hidden' => [
-            'showitem' => '
-                hidden;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:field.default.hidden,
-            ',
+            'showitem' => implode(',', [
+                'hidden;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:field.default.hidden',
+            ]),
         ],
         'language' => [
-            'showitem' => '
-                sys_language_uid;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:sys_language_uid_formlabel,
-                l10n_parent,
-            ',
+            'showitem' => implode(',', [
+                'sys_language_uid;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:sys_language_uid_formlabel',
+                'l10n_parent',
+            ]),
         ],
         'access' => [
             'label' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.access',
-            'showitem' => '
-                starttime;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:starttime_formlabel,
-                endtime;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:endtime_formlabel,
-                --linebreak--,
-                fe_group;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:fe_group_formlabel,
-            ',
+            'showitem' => implode(',', [
+                'starttime;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:starttime_formlabel',
+                'endtime;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:endtime_formlabel',
+                '--linebreak--',
+                'fe_group;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:fe_group_formlabel',
+            ]),
         ],
     ],
     'types' => [
         '1' => [
-            'showitem' => '
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
-                    --palette--;;name,
-                    --palette--;;slug,
-                    contracts,
-                --div--;LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.div.profileInformation.label,
-                    image,
-                    website_title,
-                    website,
-                    teaching_area,
-                    core_competences,
-                    memberships,
-                    supervised_thesis,
-                    supervised_doctoral_thesis,
-                    vita,
-                    publications,
-                    publications_link_title,
-                    publications_link,
-                    miscellaneous,
-                    cooperation,
-                    lectures,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
-                    --palette--;;language,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
-                    --palette--;;hidden,
-                    --palette--;;access,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended,
-            ',
+            'showitem' => implode(',', [
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general',
+                    '--palette--;;name',
+                    '--palette--;;website',
+                    'image',
+                    '--palette--;;slug',
+                '--div--;Contracts',
+                    'contracts',
+                '--div--;LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.div.unstructuredInformation.label',
+                    'teaching_area',
+                    'core_competences',
+                    'supervised_thesis',
+                    'supervised_doctoral_thesis',
+                    'miscellaneous',
+                    '--div--;LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.div.structuredInformation.label',
+                    'scientific_research',
+                    'vita',
+                    'memberships',
+                    'cooperation',
+                    '--palette--;;publications',
+                    'publications',
+                    'lectures',
+                    'press_media',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language',
+                    '--palette--;;language',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access',
+                    '--palette--;;hidden',
+                    '--palette--;;access',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended',
+            ]),
         ],
     ],
 ];
+
+function getProfileInformationConfig($type): array
+{
+    return [
+        'type' => 'inline',
+        'appearance' => [
+            'collapseAll' => true,
+            'expandSingle' => false,
+            'showNewRecordLink' => true,
+            'newRecordLinkAddTitle' => true,
+            'levelLinksPosition' => 'top',
+            'useCombination' => false,
+            'suppressCombinationWarning' => false,
+            'useSortable' => true,
+            'showPossibleLocalizationRecords' => true,
+            'showAllLocalizationLink' => true,
+            'showSynchronizationLink' => true,
+            'enabledControls' => [
+                'info' => true,
+                'new' => true,
+                'dragdrop' => true,
+                'sort' => false,
+                'hide' => true,
+                'delete' => true,
+                'localize' => true,
+            ],
+            'showPossibleRecordsSelector' => false,
+            'fileUploadAllowed' => false,
+            'fileByUrlAllowed' => false,
+            'elementBrowserEnabled' => false,
+        ],
+        'enableCascadingDelete' => true,
+        'foreign_field' => 'profile',
+        'foreign_sortby' => 'sorting',
+        'foreign_table' => 'tx_academicpersons_domain_model_profile_information',
+        'foreign_match_fields' => [
+            'type' => $type,
+        ],
+        'overrideChildTca' => [
+            'columns' => [
+                'type' => [
+                    'config' => [
+                        'default' => $type,
+                    ],
+                ],
+            ],
+        ],
+    ];
+}

--- a/Configuration/TCA/tx_academicpersons_domain_model_profile.php
+++ b/Configuration/TCA/tx_academicpersons_domain_model_profile.php
@@ -11,6 +11,55 @@ declare(strict_types=1);
 
 $lPath = 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.';
 
+$profileInformationConfig = function(string $type): array
+{
+    return [
+        'type' => 'inline',
+        'appearance' => [
+            'collapseAll' => true,
+            'expandSingle' => false,
+            'showNewRecordLink' => true,
+            'newRecordLinkAddTitle' => true,
+            'levelLinksPosition' => 'top',
+            'useCombination' => false,
+            'suppressCombinationWarning' => false,
+            'useSortable' => true,
+            'showPossibleLocalizationRecords' => true,
+            'showAllLocalizationLink' => true,
+            'showSynchronizationLink' => true,
+            'enabledControls' => [
+                'info' => true,
+                'new' => true,
+                'dragdrop' => true,
+                'sort' => false,
+                'hide' => true,
+                'delete' => true,
+                'localize' => true,
+            ],
+            'showPossibleRecordsSelector' => false,
+            'fileUploadAllowed' => false,
+            'fileByUrlAllowed' => false,
+            'elementBrowserEnabled' => false,
+        ],
+        'enableCascadingDelete' => true,
+        'foreign_field' => 'profile',
+        'foreign_sortby' => 'sorting',
+        'foreign_table' => 'tx_academicpersons_domain_model_profile_information',
+        'foreign_match_fields' => [
+            'type' => $type,
+        ],
+        'overrideChildTca' => [
+            'columns' => [
+                'type' => [
+                    'config' => [
+                        'default' => $type,
+                    ],
+                ],
+            ],
+        ],
+    ];
+};
+
 return [
     'ctrl' => [
         'label' => 'last_name',
@@ -433,37 +482,37 @@ return [
         'cooperation' => [
             'label' => $lPath . 'columns.cooperation.label',
             'exclude' => true,
-            'config' => getProfileInformationConfig('cooperation'),
+            'config' => $profileInformationConfig('cooperation'),
         ],
         'lectures' => [
             'label' => $lPath . 'columns.lectures.label',
             'exclude' => true,
-            'config' => getProfileInformationConfig('lecture'),
+            'config' => $profileInformationConfig('lecture'),
         ],
         'memberships' => [
             'label' => $lPath . 'columns.memberships.label',
             'exclude' => true,
-            'config' => getProfileInformationConfig('membership'),
+            'config' => $profileInformationConfig('membership'),
         ],
         'press_media' => [
             'label' => $lPath . 'columns.press_media.label',
             'exclude' => true,
-            'config' => getProfileInformationConfig('press_media'),
+            'config' => $profileInformationConfig('press_media'),
         ],
         'publications' => [
             'label' => $lPath . 'columns.publications.label',
             'exclude' => true,
-                'config' => getProfileInformationConfig('publication'),
+                'config' => $profileInformationConfig('publication'),
         ],
         'scientific_research' => [
             'label' => $lPath . 'columns.scientific_research.label',
             'exclude' => true,
-            'config' => getProfileInformationConfig('scientific_research'),
+            'config' => $profileInformationConfig('scientific_research'),
         ],
         'vita' => [
             'label' => $lPath . 'columns.vita.label',
             'exclude' => true,
-            'config' => getProfileInformationConfig('curriculum_vitae'),
+            'config' => $profileInformationConfig('curriculum_vitae'),
         ],
     ],
     'palettes' => [
@@ -554,56 +603,3 @@ return [
         ],
     ],
 ];
-
-/**
- * @param string $type
- * @return array<string, mixed>
- */
-function getProfileInformationConfig(string $type): array
-{
-    return [
-        'type' => 'inline',
-        'appearance' => [
-            'collapseAll' => true,
-            'expandSingle' => false,
-            'showNewRecordLink' => true,
-            'newRecordLinkAddTitle' => true,
-            'levelLinksPosition' => 'top',
-            'useCombination' => false,
-            'suppressCombinationWarning' => false,
-            'useSortable' => true,
-            'showPossibleLocalizationRecords' => true,
-            'showAllLocalizationLink' => true,
-            'showSynchronizationLink' => true,
-            'enabledControls' => [
-                'info' => true,
-                'new' => true,
-                'dragdrop' => true,
-                'sort' => false,
-                'hide' => true,
-                'delete' => true,
-                'localize' => true,
-            ],
-            'showPossibleRecordsSelector' => false,
-            'fileUploadAllowed' => false,
-            'fileByUrlAllowed' => false,
-            'elementBrowserEnabled' => false,
-        ],
-        'enableCascadingDelete' => true,
-        'foreign_field' => 'profile',
-        'foreign_sortby' => 'sorting',
-        'foreign_table' => 'tx_academicpersons_domain_model_profile_information',
-        'foreign_match_fields' => [
-            'type' => $type,
-        ],
-        'overrideChildTca' => [
-            'columns' => [
-                'type' => [
-                    'config' => [
-                        'default' => $type,
-                    ],
-                ],
-            ],
-        ],
-    ];
-}

--- a/Configuration/TCA/tx_academicpersons_domain_model_profile_information.php
+++ b/Configuration/TCA/tx_academicpersons_domain_model_profile_information.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
  * LICENSE file that was distributed with this source code.
  */
 
+ $lPath = 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile_information.';
+
 return [
     'ctrl' => [
         'label' => 'type',
@@ -18,7 +20,7 @@ return [
         'default_sortby' => 'sorting',
         'crdate' => 'crdate',
         'tstamp' => 'tstamp',
-        'title' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile_information.ctrl.label',
+        'title' => $lPath . 'ctrl.label',
         'delete' => 'deleted',
         'origUid' => 't3_origuid',
         'transOrigPointerField' => 'l10n_parent',
@@ -79,7 +81,7 @@ return [
             ],
         ],
         'profile' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile_information.columns.profile.label',
+            'label' => $lPath . 'columns.profile.label',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
@@ -88,37 +90,12 @@ return [
             ],
         ],
         'type' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile_information.columns.type.label',
             'config' => [
-                'type' => 'select',
-                'renderType' => 'selectSingle',
-                'items' => [
-                    [
-                        'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile_information.columns.type.items.curriculum_vitae.label',
-                        'curriculum_vitae',
-                    ],
-                    [
-                        'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile_information.columns.type.items.membership.label',
-                        'membership',
-                    ],
-                    [
-                        'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile_information.columns.type.items.cooperation.label',
-                        'cooperation',
-                    ],
-                    [
-                        'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile_information.columns.type.items.publication.label',
-                        'publication',
-                    ],
-                    [
-                        'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile_information.columns.type.items.lecture.label',
-                        'lecture',
-                    ],
-                ],
-                'default' => 'curriculum_vitae',
+                'type' => 'passthrough',
             ],
         ],
         'title' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile_information.columns.title.label',
+            'label' => $lPath . 'columns.title.label',
             'config' => [
                 'type' => 'input',
                 'size' => 50,
@@ -127,16 +104,15 @@ return [
             ],
         ],
         'bodytext' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile_information.columns.bodytext.label',
+            'label' => $lPath . 'columns.bodytext.label',
             'config' => [
                 'type' => 'text',
                 'cols' => 80,
                 'rows' => 5,
-                'eval' => 'required',
             ],
         ],
         'link' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile_information.columns.link.label',
+            'label' => $lPath . 'columns.link.label',
             'config' => [
                 'type' => 'input',
                 'size' => 50,
@@ -144,7 +120,33 @@ return [
             ],
         ],
         'year' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile_information.columns.year.label',
+            'label' => $lPath . 'columns.year.label',
+            'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly',
+            'config' => [
+                'type' => 'input',
+                'size' => 10,
+                'min' => 0,
+                'max' => 9999,
+                'eval' => 'int',
+            ],
+        ],
+        'year_start' => [
+            'label' => $lPath . 'columns.year_start.label',
+            'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly',
+            'config' => [
+                'type' => 'input',
+                'size' => 10,
+                'min' => 0,
+                'max' => 9999,
+                'eval' => 'int',
+            ],
+        ],
+        'year_end' => [
+            'label' => $lPath . 'columns.year_end.label',
+            'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly',
             'config' => [
                 'type' => 'input',
                 'size' => 10,
@@ -155,81 +157,108 @@ return [
         ],
     ],
     'palettes' => [
-        'general' => [
-            'label' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.general',
-            'showitem' => '
-                profile,
-                --linebreak--,
-                type,
-            ',
+        'date' => [
+            'label' => $lPath . 'palette.date',
+            'showitem' => implode(',', [
+                'year',
+                '--linebreak--',
+                'year_start',
+                'year_end',
+            ]),
         ],
         'language' => [
-            'showitem' => '
-                sys_language_uid;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:sys_language_uid_formlabel,
-                l10n_parent,
-            ',
+            'showitem' => implode(',', [
+                'sys_language_uid;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:sys_language_uid_formlabel',
+                'l10n_parent',
+            ]),
         ],
     ],
     'types' => [
         '1' => [
-            'showitem' => '
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
-                    --palette--;;general,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
-                    --palette--;;language,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended,
-            '
-        ],
-        'curriculum_vitae' => [
-            'showitem' => '
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
-                    --palette--;;general,
-                    year,
-                    title,
-                    bodytext,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
-                    --palette--;;language,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended,
-            ',
-        ],
-        'membership' => [
-            'showitem' => '
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
-                    --palette--;;general,
-                    year,
-                    title,
-                    bodytext,
-                    link,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
-                    --palette--;;language,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended,
-            ',
+            'showitem' => implode(',', [
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general',
+                    'profile',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language',
+                    '--palette--;;language',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended',
+            ]),
         ],
         'cooperation' => [
-            'showitem' => '
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
-                    --palette--;;general,
-                    year,
-                    title,
-                    link,
-                    bodytext,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
-                    --palette--;;language,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended,
-            ',
+            'showitem' => implode(',', [
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general',
+                    'profile',
+                    '--palette--;;date',
+                    'title',
+                    'link',
+                    'bodytext',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
+                    --palette--;;language',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended',
+            ]),
+        ],
+        'curriculum_vitae' => [
+            'showitem' => implode(',', [
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general',
+                    'profile',
+                    '--palette--;;date',
+                    'title',
+                    'bodytext',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
+                    --palette--;;language',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended',
+            ]),
+        ],
+        'lecture' => [
+            'showitem' => implode(',', [
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general',
+                    'profile',
+                    '--palette--;;date',
+                    'title',
+                    'link',
+                    'bodytext',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
+                    --palette--;;language',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended',
+            ]),
+        ],
+        'membership' => [
+            'showitem' => implode(',', [
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general',
+                    'profile',
+                    '--palette--;;date',
+                    'title',
+                    'link',
+                    'bodytext',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
+                    --palette--;;language',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended',
+            ]),
+        ],
+        'press_media' => [
+            'showitem' => implode(',', [
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general',
+                    'profile',
+                    '--palette--;;date',
+                    'title',
+                    'link',
+                    'bodytext',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
+                    --palette--;;language',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended',
+            ]),
         ],
         'publication' => [
-            'showitem' => '
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
-                    --palette--;;general,
-                    year,
-                    title,
-                    link,
-                    bodytext,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
-                    --palette--;;language,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended,
-            ',
+            'showitem' => implode(',', [
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general',
+                    'profile',
+                    '--palette--;;date',
+                    'title',
+                    'link',
+                    'bodytext',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
+                    --palette--;;language',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended',
+            ]),
             'columnsOverrides' => [
                 'bodytext' => [
                     'config' => [
@@ -239,18 +268,18 @@ return [
                 ],
             ],
         ],
-        'lecture' => [
-            'showitem' => '
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
-                    --palette--;;general,
-                    year,
-                    title,
-                    link,
-                    bodytext,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
-                    --palette--;;language,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended,
-            ',
+        'scientific_research' => [
+            'showitem' => implode(',', [
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general',
+                    'profile',
+                    '--palette--;;date',
+                    'title',
+                    'link',
+                    'bodytext',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
+                    --palette--;;language',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended',
+            ]),
         ],
     ],
 ];

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -81,6 +81,15 @@
             <trans-unit id="tx_academicpersons_domain_model_profile.ctrl.label">
                 <source>Profile</source>
             </trans-unit>
+            <trans-unit id="tx_academicpersons_domain_model_profile.columns.cooperation.label">
+                <source>Cooperation / Networks</source>
+            </trans-unit>
+            <trans-unit id="tx_academicpersons_domain_model_profile.columns.contracts.label">
+                <source>Employee Contracts</source>
+            </trans-unit>
+            <trans-unit id="tx_academicpersons_domain_model_profile.columns.core_competences.label">
+                <source>Main topics/core competencies</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersons_domain_model_profile.columns.gender.label">
                 <source>Gender</source>
             </trans-unit>
@@ -96,50 +105,26 @@
             <trans-unit id="tx_academicpersons_domain_model_profile.columns.gender.items.diverse">
                 <source>Diverse</source>
             </trans-unit>
-            <trans-unit id="tx_academicpersons_domain_model_profile.columns.title.label">
-                <source>Title</source>
+            <trans-unit id="tx_academicpersons_domain_model_profile.columns.image.label">
+                <source>Image</source>
             </trans-unit>
             <trans-unit id="tx_academicpersons_domain_model_profile.columns.first_name.label">
                 <source>First Name</source>
             </trans-unit>
-            <trans-unit id="tx_academicpersons_domain_model_profile.columns.middle_name.label">
-                <source>Middle Name</source>
+            <trans-unit id="tx_academicpersons_domain_model_profile.columns.first_name_alpha.label">
+                <source>First Letter of First Name</source>
             </trans-unit>
             <trans-unit id="tx_academicpersons_domain_model_profile.columns.last_name.label">
                 <source>Last Name</source>
             </trans-unit>
-            <trans-unit id="tx_academicpersons_domain_model_profile.columns.image.label">
-                <source>Image</source>
+            <trans-unit id="tx_academicpersons_domain_model_profile.columns.last_name_alpha.label">
+                <source>First Letter of Last Name</source>
             </trans-unit>
-            <trans-unit id="tx_academicpersons_domain_model_profile.columns.slug.label">
-                <source>URL Path</source>
+            <trans-unit id="tx_academicpersons_domain_model_profile.columns.lectures.label">
+                <source>Lectures</source>
             </trans-unit>
-            <trans-unit id="tx_academicpersons_domain_model_profile.columns.contracts.label">
-                <source>Employee Contracts</source>
-            </trans-unit>
-            <trans-unit id="tx_academicpersons_domain_model_profile.columns.website_title.label">
-                <source>Website Link Title</source>
-            </trans-unit>
-            <trans-unit id="tx_academicpersons_domain_model_profile.columns.website.label">
-                <source>Website</source>
-            </trans-unit>
-            <trans-unit id="tx_academicpersons_domain_model_profile.columns.teaching_area.label">
-                <source>Teaching Area</source>
-            </trans-unit>
-            <trans-unit id="tx_academicpersons_domain_model_profile.columns.core_competences.label">
-                <source>Main topics/core competencies</source>
-            </trans-unit>
-            <trans-unit id="tx_academicpersons_domain_model_profile.columns.memberships.label">
-                <source>Offices/committees/memberships</source>
-            </trans-unit>
-            <trans-unit id="tx_academicpersons_domain_model_profile.columns.supervised_thesis.label">
-                <source>Supervised theses</source>
-            </trans-unit>
-            <trans-unit id="tx_academicpersons_domain_model_profile.columns.supervised_doctoral_thesis.label">
-                <source>Supervised doctoral theses</source>
-            </trans-unit>
-            <trans-unit id="tx_academicpersons_domain_model_profile.columns.vita.label">
-                <source>Vita</source>
+            <trans-unit id="tx_academicpersons_domain_model_profile.columns.middle_name.label">
+                <source>Middle Name</source>
             </trans-unit>
             <trans-unit id="tx_academicpersons_domain_model_profile.columns.publications.label">
                 <source>Publications</source>
@@ -150,14 +135,35 @@
             <trans-unit id="tx_academicpersons_domain_model_profile.columns.publications_link.label">
                 <source>Link to external publications page</source>
             </trans-unit>
+            <trans-unit id="tx_academicpersons_domain_model_profile.columns.slug.label">
+                <source>URL Path</source>
+            </trans-unit>
+            <trans-unit id="tx_academicpersons_domain_model_profile.columns.teaching_area.label">
+                <source>Teaching Area</source>
+            </trans-unit>
+            <trans-unit id="tx_academicpersons_domain_model_profile.columns.title.label">
+                <source>Title</source>
+            </trans-unit>
+            <trans-unit id="tx_academicpersons_domain_model_profile.columns.website_title.label">
+                <source>Website Link Title</source>
+            </trans-unit>
+            <trans-unit id="tx_academicpersons_domain_model_profile.columns.memberships.label">
+                <source>Offices/committees/memberships</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersons_domain_model_profile.columns.miscellaneous.label">
                 <source>Miscellaneous information</source>
             </trans-unit>
-            <trans-unit id="tx_academicpersons_domain_model_profile.columns.cooperation.label">
-                <source>Cooperation / Networks</source>
+            <trans-unit id="tx_academicpersons_domain_model_profile.columns.supervised_doctoral_thesis.label">
+                <source>Supervised doctoral theses</source>
             </trans-unit>
-            <trans-unit id="tx_academicpersons_domain_model_profile.columns.lectures.label">
-                <source>Lectures</source>
+            <trans-unit id="tx_academicpersons_domain_model_profile.columns.supervised_thesis.label">
+                <source>Supervised theses</source>
+            </trans-unit>
+            <trans-unit id="tx_academicpersons_domain_model_profile.columns.vita.label">
+                <source>Vita</source>
+            </trans-unit>
+            <trans-unit id="tx_academicpersons_domain_model_profile.columns.website.label">
+                <source>Website</source>
             </trans-unit>
             <trans-unit id="tx_academicpersons_domain_model_profile.div.profileInformation.label">
                 <source>Personal Data</source>

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -153,6 +153,12 @@
             <trans-unit id="tx_academicpersons_domain_model_profile.columns.miscellaneous.label">
                 <source>Miscellaneous information</source>
             </trans-unit>
+            <trans-unit id="tx_academicpersons_domain_model_profile.columns.press_media.label">
+                <source>Press and Media</source>
+            </trans-unit>
+            <trans-unit id="tx_academicpersons_domain_model_profile.columns.scientific_research.label">
+                <source>Scientific Research</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersons_domain_model_profile.columns.supervised_doctoral_thesis.label">
                 <source>Supervised doctoral theses</source>
             </trans-unit>
@@ -165,8 +171,11 @@
             <trans-unit id="tx_academicpersons_domain_model_profile.columns.website.label">
                 <source>Website</source>
             </trans-unit>
-            <trans-unit id="tx_academicpersons_domain_model_profile.div.profileInformation.label">
-                <source>Personal Data</source>
+            <trans-unit id="tx_academicpersons_domain_model_profile.div.structuredInformation.label">
+                <source>Structured Information</source>
+            </trans-unit>
+            <trans-unit id="tx_academicpersons_domain_model_profile.div.unstructuredInformation.label">
+                <source>Unstructured Information</source>
             </trans-unit>
 
             <trans-unit id="tx_academicpersons_domain_model_contract.ctrl.label">
@@ -257,6 +266,12 @@
             </trans-unit>
             <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.year.label">
                 <source>Year</source>
+            </trans-unit>
+            <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.year_end.label">
+                <source>End Year</source>
+            </trans-unit>
+            <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.year_start.label">
+                <source>Start Year</source>
             </trans-unit>
             <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.profile.label">
                 <source>Profile</source>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -8,28 +8,57 @@ CREATE TABLE tx_academicpersons_domain_model_profile (
     last_name_alpha char(1) DEFAULT '' NOT NULL,
     image int(11) unsigned DEFAULT '0' NOT NULL,
     slug varchar(255) DEFAULT '' NOT NULL,
-    contracts int(11) unsigned DEFAULT '0' NOT NULL,
-		website_title varchar(80) DEFAULT '' NOT NULL,
-    website varchar(255) DEFAULT '' NOT NULL,
-    teaching_area text,
-    core_competences text,
-    memberships int(11) unsigned DEFAULT '0' NOT NULL,
-    supervised_thesis text,
-    supervised_doctoral_thesis text,
-    vita int(11) unsigned DEFAULT '0' NOT NULL,
-    publications int(11) unsigned DEFAULT '0' NOT NULL,
+
     publications_link varchar(255) DEFAULT '' NOT NULL,
     publications_link_title varchar(80) DEFAULT '' NOT NULL,
+    website varchar(255) DEFAULT '' NOT NULL,
+    website_title varchar(80) DEFAULT '' NOT NULL,
+
+    core_competences text,
     miscellaneous text,
+    supervised_thesis text,
+    supervised_doctoral_thesis text,
+    teaching_area text,
+
+    contracts int(11) unsigned DEFAULT '0' NOT NULL,
     cooperation int(11) unsigned DEFAULT '0' NOT NULL,
     lectures int(11) unsigned DEFAULT '0' NOT NULL,
+    memberships int(11) unsigned DEFAULT '0' NOT NULL,
+    press_media int(11) unsigned DEFAULT '0' NOT NULL,
+    publications int(11) unsigned DEFAULT '0' NOT NULL,
+    scientific_research int(11) unsigned DEFAULT '0' NOT NULL,
+    vita int(11) unsigned DEFAULT '0' NOT NULL,
+);
+
+CREATE TABLE tx_academicpersons_domain_model_contract (
+    profile int(11) unsigned DEFAULT '0' NOT NULL,
+    employee_type int(11) unsigned DEFAULT '0' NOT NULL,
+    position varchar(100) DEFAULT '' NOT NULL,
+    organisational_level_1 int(11) unsigned DEFAULT '0' NOT NULL,
+    organisational_level_2 int(11) unsigned DEFAULT '0' NOT NULL,
+    organisational_level_3 int(11) unsigned DEFAULT '0' NOT NULL,
+    location int(11) unsigned DEFAULT '0' NOT NULL,
+
+    room varchar(100) DEFAULT '' NOT NULL,
+    office_hours text,
+
+    physical_addresses int(11) unsigned DEFAULT '0' NOT NULL,
+    physical_addresses_from_organisation int(11) unsigned DEFAULT '0' NOT NULL,
+    phone_numbers int(11) unsigned DEFAULT '0' NOT NULL,
+    email_addresses int(11) unsigned DEFAULT '0' NOT NULL,
+
+    publish tinyint(4) unsigned DEFAULT '0' NOT NULL,
+    sorting int(11) unsigned DEFAULT '0' NOT NULL,
 );
 
 CREATE TABLE tx_academicpersons_domain_model_address (
+    contract int(11) unsigned DEFAULT '0' NOT NULL,
     employee_type int(11) unsigned DEFAULT '0' NOT NULL,
     organisational_level_1 int(11) unsigned DEFAULT '0' NOT NULL,
     organisational_level_2 int(11) unsigned DEFAULT '0' NOT NULL,
     organisational_level_3 int(11) unsigned DEFAULT '0' NOT NULL,
+    type varchar(100) DEFAULT '' NOT NULL,
+
     street varchar(120) DEFAULT '' NOT NULL,
     street_number varchar(6) DEFAULT '' NOT NULL,
     additional varchar(120) DEFAULT '' NOT NULL,
@@ -37,40 +66,23 @@ CREATE TABLE tx_academicpersons_domain_model_address (
     city varchar(100) DEFAULT '' NOT NULL,
     state varchar(60) DEFAULT '' NOT NULL,
     country varchar(100) DEFAULT '' NOT NULL,
-    type varchar(100) DEFAULT '' NOT NULL,
-    contract int(11) unsigned DEFAULT '0' NOT NULL,
+
     sorting int(11) unsigned DEFAULT '0' NOT NULL,
 );
 
 CREATE TABLE tx_academicpersons_domain_model_email (
-    email varchar(255) DEFAULT '' NOT NULL,
-    type varchar(100) DEFAULT '' NOT NULL,
     contract int(11) unsigned DEFAULT '0' NOT NULL,
+    type varchar(100) DEFAULT '' NOT NULL,
+    email varchar(255) DEFAULT '' NOT NULL,
+
     sorting int(11) unsigned DEFAULT '0' NOT NULL,
 );
 
 CREATE TABLE tx_academicpersons_domain_model_phone_number (
-    phone_number varchar(60) DEFAULT '' NOT NULL,
-    type varchar(100) DEFAULT '' NOT NULL,
     contract int(11) unsigned DEFAULT '0' NOT NULL,
-    sorting int(11) unsigned DEFAULT '0' NOT NULL,
-);
-
-CREATE TABLE tx_academicpersons_domain_model_contract (
-    employee_type int(11) unsigned DEFAULT '0' NOT NULL,
-    organisational_level_1 int(11) unsigned DEFAULT '0' NOT NULL,
-    organisational_level_2 int(11) unsigned DEFAULT '0' NOT NULL,
-    organisational_level_3 int(11) unsigned DEFAULT '0' NOT NULL,
-    physical_addresses_from_organisation int(11) unsigned DEFAULT '0' NOT NULL,
-    physical_addresses int(11) unsigned DEFAULT '0' NOT NULL,
-    position varchar(100) DEFAULT '' NOT NULL,
-    location int(11) unsigned DEFAULT '0' NOT NULL,
-    room varchar(100) DEFAULT '' NOT NULL,
-    phone_numbers int(11) unsigned DEFAULT '0' NOT NULL,
-    email_addresses int(11) unsigned DEFAULT '0' NOT NULL,
-    office_hours text,
-    publish tinyint(4) unsigned DEFAULT '0' NOT NULL,
-    profile int(11) unsigned DEFAULT '0' NOT NULL,
+    type varchar(100) DEFAULT '' NOT NULL,
+    phone_number varchar(60) DEFAULT '' NOT NULL,
+    
     sorting int(11) unsigned DEFAULT '0' NOT NULL,
 );
 
@@ -83,11 +95,15 @@ CREATE TABLE tx_academicpersons_domain_model_location (
 );
 
 CREATE TABLE tx_academicpersons_domain_model_profile_information (
+    profile int(11) unsigned DEFAULT '0' NOT NULL,
     type varchar(100) DEFAULT '' NOT NULL,
+
     title varchar(255) DEFAULT '' NOT NULL,
     bodytext text,
     link varchar(2048) DEFAULT '' NOT NULL,
     year int(4) DEFAULT '0' NOT NULL,
-    profile int(11) unsigned DEFAULT '0' NOT NULL,
+    year_start int(4) DEFAULT '0' NOT NULL,
+    year_end int(4) DEFAULT '0' NOT NULL,
+
     sorting int(11) unsigned DEFAULT '0' NOT NULL,
 );


### PR DESCRIPTION
- Optimize and extend ext_tables.sql (group columns by usage, add new columns)
- Optimize TCA
  - Add new profile information types
  - Add start and end year fields
  - Resort by context and type
  - Use `implode()`for showitem field list
  - Set fields to read only in translations, which, as expected, should not be translated (e.g. first name, last name, ...)
  - Hide type field for profile information records as the records get connected automatically
  - Add translation options to profile information records
  - Set recurring config for profile information records by function
  - Shorten language labels by prefix variable
- Add language labels