### PR TITLE
Adjust speaking url for list plugin

### DIFF
--- a/Configuration/Routes/List.yaml
+++ b/Configuration/Routes/List.yaml
@@ -4,7 +4,7 @@ routeEnhancers:
     extension: AcademicPersons
     plugin: List
     routes:
-      - routePath: '/{page}'
+      - routePath: 'page-{page}'
         _controller: 'Profile::list'
         _arguments:
           page: 'demand/currentPage'
@@ -20,5 +20,5 @@ routeEnhancers:
         end: '1000'
       letter:
         type: StaticRangeMapper
-        start: 'A'
-        end: 'Z'
+        start: 'a'
+        end: 'z'

--- a/Configuration/Routes/List.yaml
+++ b/Configuration/Routes/List.yaml
@@ -4,7 +4,7 @@ routeEnhancers:
     extension: AcademicPersons
     plugin: List
     routes:
-      - routePath: 'page-{page}'
+      - routePath: '{localized_page}-{page}'
         _controller: 'Profile::list'
         _arguments:
           page: 'demand/currentPage'
@@ -14,6 +14,14 @@ routeEnhancers:
           letter: 'demand/alphabetFilter'
     defaultController: 'Profile::list'
     aspects:
+      localized_page:
+        type: LocaleModifier
+        default: 'page'
+        localeMap:
+          - locale: 'en_EN.*'
+            value: 'page'
+          - locale: 'de_DE.*'
+            value: 'seite'
       page:
         type: StaticRangeMapper
         start: '1'


### PR DESCRIPTION
[TASK] Adjust speaking url: use lower case a-z for alphabet urls. Display page-number instead of only number (.../page-1 instead of .../1)