### PR TITLE
Remove conflicting TCA configuration for addresses and add implodes and label functions

### DIFF
--- a/Configuration/TCA/tx_academicpersons_domain_model_address.php
+++ b/Configuration/TCA/tx_academicpersons_domain_model_address.php
@@ -2,22 +2,29 @@
 
 declare(strict_types=1);
 
-/*
+/**
  * This file is part of the "academic_persons" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE file that was distributed with this source code.
  */
 
+$ll = fn (string $langKey): string => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_address.' . $langKey;
+
 return [
     'ctrl' => [
         'label' => 'type',
-        'label_alt' => 'street,street_number,zip,city',
+        'label_alt' => implode(',', [
+            'street',
+            'street_number',
+            'zip',
+            'city',
+        ]),
         'label_alt_force' => true,
         'default_sortby' => 'sorting',
         'crdate' => 'crdate',
         'tstamp' => 'tstamp',
-        'title' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_address.ctrl.label',
+        'title' => $ll('ctrl.label'),
         'delete' => 'deleted',
         'hideTable' => true,
         'origUid' => 't3_origuid',
@@ -28,7 +35,14 @@ return [
         'enablecolumns' => [
             'disabled' => 'hidden',
         ],
-        'searchFields' => 'street,zip,city,state,country,additional',
+        'searchFields' => implode(',', [
+            'street',
+            'zip',
+            'city',
+            'state',
+            'country',
+            'additional',
+        ]),
         'typeicon_classes' => [
             'default' => 'tx_academicpersons_domain_model_address',
         ],
@@ -77,8 +91,13 @@ return [
                 'type' => 'passthrough',
             ],
         ],
+        'contract' => [
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
         'employee_type' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_address.columns.employee_type.label',
+            'label' => $ll('columns.employee_type.label'),
             'l10n_display' => 'defaultAsReadonly',
             'l10n_mode' => 'exclude',
             'displayCond' => 'FIELD:contract:REQ:false',
@@ -90,7 +109,7 @@ return [
             ],
         ],
         'organisational_level_1' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_address.columns.organisational_level_1.label',
+            'label' => $ll('columns.organisational_level_1.label'),
             'l10n_display' => 'defaultAsReadonly',
             'l10n_mode' => 'exclude',
             'displayCond' => 'FIELD:contract:REQ:false',
@@ -102,7 +121,7 @@ return [
             ],
         ],
         'organisational_level_2' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_address.columns.organisational_level_2.label',
+            'label' => $ll('columns.organisational_level_2.label'),
             'l10n_display' => 'defaultAsReadonly',
             'l10n_mode' => 'exclude',
             'displayCond' => 'FIELD:contract:REQ:false',
@@ -114,7 +133,7 @@ return [
             ],
         ],
         'organisational_level_3' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_address.columns.organisational_level_3.label',
+            'label' => $ll('columns.organisational_level_3.label'),
             'l10n_display' => 'defaultAsReadonly',
             'l10n_mode' => 'exclude',
             'displayCond' => 'FIELD:contract:REQ:false',
@@ -126,7 +145,7 @@ return [
             ],
         ],
         'street' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_address.columns.street.label',
+            'label' => $ll('columns.street.label'),
             'config' => [
                 'type' => 'input',
                 'size' => 50,
@@ -135,7 +154,7 @@ return [
             ],
         ],
         'street_number' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_address.columns.street_number.label',
+            'label' => $ll('columns.street_number.label'),
             'config' => [
                 'type' => 'input',
                 'size' => 10,
@@ -143,7 +162,7 @@ return [
             ],
         ],
         'additional' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_address.columns.additional.label',
+            'label' => $ll('columns.additional.label'),
             'config' => [
                 'type' => 'input',
                 'size' => 50,
@@ -151,7 +170,7 @@ return [
             ],
         ],
         'zip' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_address.columns.zip.label',
+            'label' => $ll('columns.zip.label'),
             'config' => [
                 'type' => 'input',
                 'size' => 10,
@@ -160,7 +179,7 @@ return [
             ],
         ],
         'city' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_address.columns.city.label',
+            'label' => $ll('columns.city.label'),
             'config' => [
                 'type' => 'input',
                 'size' => 50,
@@ -169,7 +188,7 @@ return [
             ],
         ],
         'state' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_address.columns.state.label',
+            'label' => $ll('columns.state.label'),
             'config' => [
                 'type' => 'input',
                 'size' => 50,
@@ -177,7 +196,7 @@ return [
             ],
         ],
         'country' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_address.columns.country.label',
+            'label' => $ll('columns.country.label'),
             'config' => [
                 'type' => 'input',
                 'size' => 50,
@@ -186,21 +205,19 @@ return [
             ],
         ],
         'type' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_address.columns.type.label',
+            'label' => $ll('columns.type.label'),
             'l10n_mode' => 'exclude',
             'l10n_display' => 'defaultAsReadonly',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'items' => [
-                    ['LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_address.columns.type.items.undefined.label', ''],
+                    [
+                        $ll('columns.type.items.undefined.label'),
+                        ''
+                    ],
                 ],
                 'itemsProcFunc' => \Fgtclb\AcademicPersons\Tca\RecordTypes::class . '->getPhysicalAddressTypes',
-            ],
-        ],
-        'contract' => [
-            'config' => [
-                'type' => 'passthrough',
             ],
         ],
     ],

--- a/Configuration/TCA/tx_academicpersons_domain_model_contract.php
+++ b/Configuration/TCA/tx_academicpersons_domain_model_contract.php
@@ -192,10 +192,6 @@ return [
                 'foreign_field' =>  'contract',
                 'foreign_sortby' => 'sorting',
                 'foreign_table' => 'tx_academicpersons_domain_model_address',
-                'MM' => 'tx_academicpersons_contract_address_mm',
-                'MM_match_fields' => [
-                    'fieldname' => 'physical_addresses',
-                ],
             ],
         ],
         'email_addresses' => [

--- a/Configuration/TCA/tx_academicpersons_domain_model_contract.php
+++ b/Configuration/TCA/tx_academicpersons_domain_model_contract.php
@@ -2,12 +2,14 @@
 
 declare(strict_types=1);
 
-/*
+/**
  * This file is part of the "academic_persons" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE file that was distributed with this source code.
  */
+
+$ll = fn (string $langKey): string => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_contract.' . $langKey;
 
 return [
     'ctrl' => [
@@ -16,7 +18,7 @@ return [
         'default_sortby' => 'sorting',
         'crdate' => 'crdate',
         'tstamp' => 'tstamp',
-        'title' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_contract.ctrl.label',
+        'title' => $ll('ctrl.label'),
         'delete' => 'deleted',
         'hideTable' => true,
         'origUid' => 't3_origuid',
@@ -78,20 +80,12 @@ return [
             ],
         ],
         'profile' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_contract.columns.profile.label',
             'config' => [
-                'type' => 'select',
-                'renderType' => 'selectSingle',
-                'items' => [
-                    ['', 0],
-                ],
-                'foreign_table' => 'tx_academicpersons_domain_model_profile',
-                'minitems' => 1,
-                'default' => 0,
+                'type' => 'passthrough',
             ],
         ],
         'employee_type' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_contract.columns.employee_type.label',
+            'label' => $ll('columns.employee_type.label'),
             'l10n_mode' => 'exclude',
             'l10n_display' => 'defaultAsReadonly',
             'config' => [
@@ -103,7 +97,7 @@ return [
             ],
         ],
         'organisational_level_1' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_contract.columns.organisational_level_1.label',
+            'label' => $ll('columns.organisational_level_1.label'),
             'l10n_mode' => 'exclude',
             'l10n_display' => 'defaultAsReadonly',
             'config' => [
@@ -114,7 +108,7 @@ return [
             ],
         ],
         'organisational_level_2' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_contract.columns.organisational_level_2.label',
+            'label' => $ll('columns.organisational_level_2.label'),
             'l10n_mode' => 'exclude',
             'l10n_display' => 'defaultAsReadonly',
             'config' => [
@@ -125,7 +119,7 @@ return [
             ],
         ],
         'organisational_level_3' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_contract.columns.organisational_level_3.label',
+            'label' => $ll('columns.organisational_level_3.label'),
             'l10n_mode' => 'exclude',
             'l10n_display' => 'defaultAsReadonly',
             'config' => [
@@ -136,7 +130,7 @@ return [
             ],
         ],
         'physical_addresses_from_organisation' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_contract.columns.physical_addresses_from_organisation.label',
+            'label' => $ll('columns.physical_addresses_from_organisation.label'),
             'exclude' => true,
             'config' => [
                 'type' => 'select',
@@ -158,7 +152,7 @@ return [
             ],
         ],
         'physical_addresses' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_contract.columns.physical_addresses.label',
+            'label' => $ll('columns.physical_addresses.label'),
             'exclude' => true,
             'config' => [
                 'type' => 'inline',
@@ -195,7 +189,7 @@ return [
             ],
         ],
         'email_addresses' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_contract.columns.email_addresses.label',
+            'label' => $ll('columns.email_addresses.label'),
             'exclude' => true,
             'config' => [
                 'type' => 'inline',
@@ -232,7 +226,7 @@ return [
             ],
         ],
         'phone_numbers' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_contract.columns.phone_numbers.label',
+            'label' => $ll('columns.phone_numbers.label'),
             'exclude' => true,
             'config' => [
                 'type' => 'inline',
@@ -269,7 +263,7 @@ return [
             ],
         ],
         'position' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_contract.columns.position.label',
+            'label' => $ll('columns.position.label'),
             'exclude' => true,
             'config' => [
                 'type' => 'input',
@@ -278,7 +272,7 @@ return [
             ],
         ],
         'location' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_contract.columns.location.label',
+            'label' => $ll('columns.location.label'),
             'exclude' => true,
             'config' => [
                 'type' => 'select',
@@ -289,7 +283,7 @@ return [
             ],
         ],
         'room' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_contract.columns.room.label',
+            'label' => $ll('columns.room.label'),
             'exclude' => true,
             'config' => [
                 'type' => 'input',
@@ -298,7 +292,7 @@ return [
             ],
         ],
         'office_hours' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_contract.columns.office_hours.label',
+            'label' => $ll('columns.office_hours.label'),
             'exclude' => true,
             'config' => [
                 'type' => 'text',
@@ -307,7 +301,7 @@ return [
             ],
         ],
         'publish' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_contract.columns.publish.label',
+            'label' => $ll('columns.publish.label'),
             'exclude' => true,
             'config' => [
                 'type' => 'check',
@@ -324,37 +318,37 @@ return [
     ],
     'palettes' => [
         'general' => [
-            'showitem' => '
-                profile,
-                publish,
-                employee_type,
-                --linebreak--,
-                organisational_level_1,
-                organisational_level_2,
-                organisational_level_3,
-            ',
+            'showitem' => implode(',', [
+                'profile',
+                'publish',
+                'employee_type',
+                '--linebreak--',
+                'organisational_level_1',
+                'organisational_level_2',
+                'organisational_level_3',
+            ]),
         ],
         'contactInformation' => [
-            'showitem' => '
-                location,
-                room,
-                --linebreak--,
-                position,
-            ',
+            'showitem' => implode(',', [
+                'location',
+                'room',
+                '--linebreak--',
+                'position',
+            ]),
         ],
     ],
     'types' => [
         '0' => [
-            'showitem' => '
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
-                    --palette--;;general,
-                    --palette--;;contactInformation,
-                    office_hours,
-                    physical_addresses_from_organisation,
-                    physical_addresses,
-                    email_addresses,
-                    phone_numbers,
-            ',
+            'showitem' => implode(',', [
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general',
+                    '--palette--;;general',
+                    '--palette--;;contactInformation',
+                    'office_hours',
+                    'physical_addresses_from_organisation',
+                    'physical_addresses',
+                    'email_addresses',
+                    'phone_numbers',
+            ]),
         ],
     ],
 ];

--- a/Configuration/TCA/tx_academicpersons_domain_model_email.php
+++ b/Configuration/TCA/tx_academicpersons_domain_model_email.php
@@ -2,20 +2,22 @@
 
 declare(strict_types=1);
 
-/*
+/**
  * This file is part of the "academic_persons" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE file that was distributed with this source code.
  */
 
+$ll = fn (string $langKey): string => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_email.' . $langKey;
+ 
 return [
     'ctrl' => [
         'label' => 'email',
         'default_sortby' => 'sorting',
         'crdate' => 'crdate',
         'tstamp' => 'tstamp',
-        'title' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_email.ctrl.label',
+        'title' => $ll('ctrl.label'),
         'delete' => 'deleted',
         'hideTable' => true,
         'origUid' => 't3_origuid',
@@ -75,8 +77,13 @@ return [
                 'type' => 'passthrough',
             ],
         ],
+        'contract' => [
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
         'email' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_email.columns.email.label',
+            'label' => $ll('columns.email.label'),
             'config' => [
                 'type' => 'input',
                 'size' => 50,
@@ -85,52 +92,46 @@ return [
             ],
         ],
         'type' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_email.columns.type.label',
+            'label' => $ll('columns.type.label'),
             'l10n_mode' => 'exclude',
             'l10n_display' => 'defaultAsReadonly',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'items' => [
-                    ['LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_email.columns.type.items.undefined.label', ''],
+                    [
+                        $ll('columns.type.items.undefined.label'),
+                        ''
+                    ],
                 ],
                 'itemsProcFunc' => \Fgtclb\AcademicPersons\Tca\RecordTypes::class . '->getEmailAddressTypes',
-            ],
-        ],
-        'contract' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_email.columns.contract.label',
-            'config' => [
-                'type' => 'select',
-                'renderType' => 'selectSingle',
-                'readOnly' => true,
-                'foreign_table' => 'tx_academicpersons_domain_model_contract',
             ],
         ],
     ],
     'palettes' => [
         'general' => [
             'label' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.general',
-            'showitem' => '
-                email,
-                type,
-            ',
+            'showitem' => implode(',', [
+                'email',
+                'type',
+            ]),
         ],
         'language' => [
-            'showitem' => '
-                sys_language_uid;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:sys_language_uid_formlabel,
-                l10n_parent,
-            ',
+            'showitem' => implode(',', [
+                'sys_language_uid;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:sys_language_uid_formlabel',
+                'l10n_parent',
+            ]),
         ],
     ],
     'types' => [
         '1' => [
-            'showitem' => '
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
-                    --palette--;;general,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
-                    --palette--;;language,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended,
-            ',
+            'showitem' => implode(',', [
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general',
+                    '--palette--;;general',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language',
+                    '--palette--;;language',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended',
+            ]),
         ],
     ],
 ];

--- a/Configuration/TCA/tx_academicpersons_domain_model_location.php
+++ b/Configuration/TCA/tx_academicpersons_domain_model_location.php
@@ -2,12 +2,14 @@
 
 declare(strict_types=1);
 
-/*
+/**
  * This file is part of the "academic_persons" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE file that was distributed with this source code.
  */
+
+$ll = fn (string $langKey): string => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_location.' . $langKey;
 
 return [
     'ctrl' => [
@@ -15,7 +17,7 @@ return [
         'default_sortby' => 'title asc',
         'crdate' => 'crdate',
         'tstamp' => 'tstamp',
-        'title' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_location.ctrl.label',
+        'title' => $ll('ctrl.label'),
         'delete' => 'deleted',
         'origUid' => 't3_origuid',
         'transOrigPointerField' => 'l10n_parent',
@@ -75,7 +77,7 @@ return [
             ],
         ],
         'title' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_location.columns.title.label',
+            'label' => $ll('columns.title.label'),
             'config' => [
                 'type' => 'input',
                 'size' => 50,
@@ -87,26 +89,26 @@ return [
     'palettes' => [
         'general' => [
             'label' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.general',
-            'showitem' => '
-                title,
-            ',
+            'showitem' => implode(',', [
+                'title',
+            ]),
         ],
         'language' => [
-            'showitem' => '
-                sys_language_uid;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:sys_language_uid_formlabel,
-                l10n_parent,
-            ',
+            'showitem' => implode(',', [
+                'sys_language_uid;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:sys_language_uid_formlabel',
+                'l10n_parent',
+            ]),
         ],
     ],
     'types' => [
         '1' => [
-            'showitem' => '
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
-                    --palette--;;general,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
-                    --palette--;;language,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended,
-            ',
+            'showitem' => implode(',', [
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general',
+                    '--palette--;;general',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language',
+                    '--palette--;;language',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended',
+            ]),
         ],
     ],
 ];

--- a/Configuration/TCA/tx_academicpersons_domain_model_phone_number.php
+++ b/Configuration/TCA/tx_academicpersons_domain_model_phone_number.php
@@ -2,12 +2,14 @@
 
 declare(strict_types=1);
 
-/*
+/**
  * This file is part of the "academic_persons" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE file that was distributed with this source code.
  */
+
+$ll = fn (string $langKey): string => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_phone_number.' . $langKey;
 
 return [
     'ctrl' => [
@@ -15,7 +17,7 @@ return [
         'default_sortby' => 'sorting',
         'crdate' => 'crdate',
         'tstamp' => 'tstamp',
-        'title' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_phone_number.ctrl.label',
+        'title' => $ll('ctrl.label'),
         'delete' => 'deleted',
         'hideTable' => true,
         'origUid' => 't3_origuid',
@@ -26,7 +28,9 @@ return [
         'enablecolumns' => [
             'disabled' => 'hidden',
         ],
-        'searchFields' => 'phone_number',
+        'searchFields' => implode(',', [
+            'phone_number',
+        ]),
         'typeicon_classes' => [
             'default' => 'tx_academicpersons_domain_model_phone_number',
         ],
@@ -75,8 +79,13 @@ return [
                 'type' => 'passthrough',
             ],
         ],
+        'contract' => [
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
         'phone_number' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_phone_number.columns.phone_number.label',
+            'label' => $ll('columns.phone_number.label'),
             'config' => [
                 'type' => 'input',
                 'size' => 50,
@@ -85,52 +94,46 @@ return [
             ],
         ],
         'type' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_phone_number.columns.type.label',
+            'label' => $ll('columns.type.label'),
             'l10n_mode' => 'exclude',
             'l10n_display' => 'defaultAsReadonly',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'items' => [
-                    ['LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_phone_number.columns.type.items.undefined.label', ''],
+                    [
+                        $ll('columns.type.items.undefined.label'),
+                        ''
+                    ],
                 ],
                 'itemsProcFunc' => \Fgtclb\AcademicPersons\Tca\RecordTypes::class . '->getPhoneNumberTypes',
-            ],
-        ],
-        'contract' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_phone_number.columns.contract.label',
-            'config' => [
-                'type' => 'select',
-                'renderType' => 'selectSingle',
-                'readOnly' => true,
-                'foreign_table' => 'tx_academicpersons_domain_model_contract',
             ],
         ],
     ],
     'palettes' => [
         'general' => [
             'label' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.general',
-            'showitem' => '
-                phone_number,
-                type,
-            ',
+            'showitem' => implode(',', [
+                'phone_number',
+                'type',
+            ]),
         ],
         'language' => [
-            'showitem' => '
-                sys_language_uid;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:sys_language_uid_formlabel,
-                l10n_parent,
-            ',
+            'showitem' => implode(',', [
+                'sys_language_uid;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:sys_language_uid_formlabel',
+                'l10n_parent',
+            ]),
         ],
     ],
     'types' => [
         '1' => [
-            'showitem' => '
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
-                    --palette--;;general,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
-                    --palette--;;language,
-                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended,
-            ',
+            'showitem' => implode(',', [
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general',
+                    '--palette--;;general',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language',
+                    '--palette--;;language',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended',
+            ]),
         ],
     ],
 ];

--- a/Configuration/TCA/tx_academicpersons_domain_model_profile.php
+++ b/Configuration/TCA/tx_academicpersons_domain_model_profile.php
@@ -68,7 +68,7 @@ return [
         'default_sortby' => 'last_name',
         'crdate' => 'crdate',
         'tstamp' => 'tstamp',
-        'title' => $lPath . 'ctrl.label',
+        'title' => $ll('ctrl.label'),
         'delete' => 'deleted',
         'origUid' => 't3_origuid',
         'transOrigPointerField' => 'l10n_parent',
@@ -188,7 +188,7 @@ return [
             ],
         ],
         'slug' => [
-            'label' => $lPath . 'columns.slug.label',
+            'label' => $ll('columns.slug.label'),
             'exclude' => true,
             'l10n_mode' => 'exclude',
             'l10n_display' => 'defaultAsReadonly',
@@ -213,7 +213,7 @@ return [
             ],
         ],
         'gender' => [
-            'label' => $lPath . 'columns.gender.label',
+            'label' => $ll('columns.gender.label'),
             'l10n_mode' => 'exclude',
             'l10n_display' => 'defaultAsReadonly',
             'config' => [
@@ -221,19 +221,19 @@ return [
                 'renderType' => 'selectSingle',
                 'items' => [
                     [
-                        $lPath . 'columns.gender.items.none',
+                        $ll('columns.gender.items.none'),
                         '',
                     ],
                     [
-                        $lPath . 'columns.gender.items.mr',
+                        $ll('columns.gender.items.mr'),
                         'mr',
                     ],
                     [
-                        $lPath . 'columns.gender.items.ms',
+                        $ll('columns.gender.items.ms'),
                         'ms',
                     ],
                     [
-                        $lPath . 'columns.gender.items.diverse',
+                        $ll('columns.gender.items.diverse'),
                         'diverse',
                     ],
                 ],
@@ -241,7 +241,7 @@ return [
             ],
         ],
         'title' => [
-            'label' => $lPath . 'columns.title.label',
+            'label' => $ll('columns.title.label'),
             'config' => [
                 'type' => 'input',
                 'size' => 50,
@@ -249,7 +249,7 @@ return [
             ],
         ],
         'first_name' => [
-            'label' => $lPath . 'columns.first_name.label',
+            'label' => $ll('columns.first_name.label'),
             'l10n_mode' => 'exclude',
             'l10n_display' => 'defaultAsReadonly',
             'config' => [
@@ -260,7 +260,7 @@ return [
             ],
         ],
         'first_name_alpha' => [
-            'label' => $lPath . 'columns.first_name_alpha.label',
+            'label' => $ll('columns.first_name_alpha.label'),
             'l10n_mode' => 'exclude',
             'l10n_display' => 'defaultAsReadonly',
             'config' => [
@@ -271,7 +271,7 @@ return [
             ],
         ],
         'middle_name' => [
-            'label' => $lPath . 'columns.middle_name.label',
+            'label' => $ll('columns.middle_name.label'),
             'l10n_mode' => 'exclude',
             'l10n_display' => 'defaultAsReadonly',
             'config' => [
@@ -281,7 +281,7 @@ return [
             ],
         ],
         'last_name' => [
-            'label' => $lPath . 'columns.last_name.label',
+            'label' => $ll('columns.last_name.label'),
             'l10n_mode' => 'exclude',
             'l10n_display' => 'defaultAsReadonly',
             'config' => [
@@ -292,7 +292,7 @@ return [
             ],
         ],
         'last_name_alpha' => [
-            'label' => $lPath . 'columns.last_name_alpha.label',
+            'label' => $ll('columns.last_name_alpha.label'),
             'l10n_mode' => 'exclude',
             'l10n_display' => 'defaultAsReadonly',
             'config' => [
@@ -303,7 +303,7 @@ return [
             ],
         ],
         'image' => [
-            'label' => $lPath . 'columns.image.label',
+            'label' => $ll('columns.image.label'),
             'l10n_mode' => 'exclude',
             'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig(
                 'image',
@@ -335,7 +335,7 @@ return [
             ),
         ],
         'contracts' => [
-            'label' => $lPath . 'columns.contracts.label',
+            'label' => $ll('columns.contracts.label'),
             'exclude' => true,
             'config' => [
                 'type' => 'inline',
@@ -372,7 +372,7 @@ return [
             ],
         ],
         'website_title' => [
-            'label' => $lPath . 'columns.website_title.label',
+            'label' => $ll('columns.website_title.label'),
             'config' => [
                 'type' => 'input',
                 'size' => 50,
@@ -380,7 +380,7 @@ return [
             ],
         ],
         'website' => [
-            'label' => $lPath . 'columns.website.label',
+            'label' => $ll('columns.website.label'),
             'l10n_mode' => 'exclude',
             'l10n_display' => 'defaultAsReadonly',
             'config' => [
@@ -390,7 +390,7 @@ return [
             ],
         ],
         'teaching_area' => [
-            'label' => $lPath . 'columns.teaching_area.label',
+            'label' => $ll('columns.teaching_area.label'),
             'exclude' => true,
             'config' => [
                 'type' => 'text',
@@ -399,7 +399,7 @@ return [
             ],
         ],
         'core_competences' => [
-            'label' => $lPath . 'columns.core_competences.label',
+            'label' => $ll('columns.core_competences.label'),
             'exclude' => true,
             'config' => [
                 'type' => 'text',
@@ -408,7 +408,7 @@ return [
             ],
         ],
         'supervised_thesis' => [
-            'label' => $lPath . 'columns.supervised_thesis.label',
+            'label' => $ll('columns.supervised_thesis.label'),
             'exclude' => true,
             'config' => [
                 'type' => 'text',
@@ -417,7 +417,7 @@ return [
             ],
         ],
         'supervised_doctoral_thesis' => [
-            'label' => $lPath . 'columns.supervised_doctoral_thesis.label',
+            'label' => $ll('columns.supervised_doctoral_thesis.label'),
             'exclude' => true,
             'config' => [
                 'type' => 'text',
@@ -426,7 +426,7 @@ return [
             ],
         ],
         'miscellaneous' => [
-            'label' => $lPath . 'columns.miscellaneous.label',
+            'label' => $ll('columns.miscellaneous.label'),
             'exclude' => true,
             'config' => [
                 'type' => 'text',
@@ -435,7 +435,7 @@ return [
             ],
         ],
         'publications_link_title' => [
-            'label' => $lPath . 'columns.publications_link_title.label',
+            'label' => $ll('columns.publications_link_title.label'),
             'exclude' => true,
             'config' => [
                 'type' => 'input',
@@ -444,7 +444,7 @@ return [
             ],
         ],
         'publications_link' => [
-            'label' => $lPath . 'columns.publications_link.label',
+            'label' => $ll('columns.publications_link.label'),
             'l10n_mode' => 'exclude',
             'l10n_display' => 'defaultAsReadonly',
             'exclude' => true,
@@ -455,37 +455,37 @@ return [
             ],
         ],
         'cooperation' => [
-            'label' => $lPath . 'columns.cooperation.label',
+            'label' => $ll('columns.cooperation.label'),
             'exclude' => true,
             'config' => $profileInformationConfig('cooperation'),
         ],
         'lectures' => [
-            'label' => $lPath . 'columns.lectures.label',
+            'label' => $ll('columns.lectures.label'),
             'exclude' => true,
             'config' => $profileInformationConfig('lecture'),
         ],
         'memberships' => [
-            'label' => $lPath . 'columns.memberships.label',
+            'label' => $ll('columns.memberships.label'),
             'exclude' => true,
             'config' => $profileInformationConfig('membership'),
         ],
         'press_media' => [
-            'label' => $lPath . 'columns.press_media.label',
+            'label' => $ll('columns.press_media.label'),
             'exclude' => true,
             'config' => $profileInformationConfig('press_media'),
         ],
         'publications' => [
-            'label' => $lPath . 'columns.publications.label',
+            'label' => $ll('columns.publications.label'),
             'exclude' => true,
                 'config' => $profileInformationConfig('publication'),
         ],
         'scientific_research' => [
-            'label' => $lPath . 'columns.scientific_research.label',
+            'label' => $ll('columns.scientific_research.label'),
             'exclude' => true,
             'config' => $profileInformationConfig('scientific_research'),
         ],
         'vita' => [
-            'label' => $lPath . 'columns.vita.label',
+            'label' => $ll('columns.vita.label'),
             'exclude' => true,
             'config' => $profileInformationConfig('curriculum_vitae'),
         ],

--- a/Configuration/TCA/tx_academicpersons_domain_model_profile.php
+++ b/Configuration/TCA/tx_academicpersons_domain_model_profile.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-/*
+/**
  * This file is part of the "academic_persons" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE file that was distributed with this source code.
  */
 
-$lPath = 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.';
+$ll = fn (string $langKey): string => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.' . $langKey;
 
 $profileInformationConfig = function(string $type): array
 {

--- a/Configuration/TCA/tx_academicpersons_domain_model_profile_information.php
+++ b/Configuration/TCA/tx_academicpersons_domain_model_profile_information.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  * LICENSE file that was distributed with this source code.
  */
 
- $lPath = 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile_information.';
+$lPath = 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile_information.';
 
 return [
     'ctrl' => [


### PR DESCRIPTION
## Changes

- Remove conflicting TCA configuration for addresses, which prevented adding of new addresse (1:n vs. n:m)
- Move from strings to imploded arrays for showitem configurations
- Add prefix for language label keys by function to shorten label paths
