### PR TITLE
Add localization buttons to all childs of contracts

### DIFF
--- a/Configuration/TCA/tx_academicpersons_domain_model_contract.php
+++ b/Configuration/TCA/tx_academicpersons_domain_model_contract.php
@@ -166,8 +166,8 @@ return [
                     'suppressCombinationWarning' => false,
                     'useSortable' => true,
                     'showPossibleLocalizationRecords' => true,
-                    'showAllLocalizationLink' => false,
-                    'showSynchronizationLink' => false,
+                    'showAllLocalizationLink' => true,
+                    'showSynchronizationLink' => true,
                     'enabledControls' => [
                         'info' => true,
                         'new' =>  true,
@@ -203,8 +203,8 @@ return [
                     'suppressCombinationWarning' => false,
                     'useSortable' => true,
                     'showPossibleLocalizationRecords' => true,
-                    'showAllLocalizationLink' => false,
-                    'showSynchronizationLink' => false,
+                    'showAllLocalizationLink' => true,
+                    'showSynchronizationLink' => true,
                     'enabledControls' => [
                         'info' => true,
                         'new' =>  true,
@@ -240,8 +240,8 @@ return [
                     'suppressCombinationWarning' => false,
                     'useSortable' => true,
                     'showPossibleLocalizationRecords' => true,
-                    'showAllLocalizationLink' => false,
-                    'showSynchronizationLink' => false,
+                    'showAllLocalizationLink' => true,
+                    'showSynchronizationLink' => true,
                     'enabledControls' => [
                         'info' => true,
                         'new' =>  true,


### PR DESCRIPTION
Enable the buttons to localize or synchronize all child records (addresses, email addresses and phone numbers) in the TCA of contracts.