### PR TITLE
Add missing accurate sorting if grouping is active

### DIFF
--- a/Classes/Domain/Repository/ProfileRepository.php
+++ b/Classes/Domain/Repository/ProfileRepository.php
@@ -98,7 +98,9 @@ class ProfileRepository extends Repository
 
         if (in_array($demand->getGroupBy(), $allowedGroupingValues, true)) {
             $orderings[$demand->getGroupBy()] = QueryInterface::ORDER_ASCENDING;
-        } elseif (
+        }
+        
+        if (
             in_array($demand->getSortBy(), $allowedSortByValues, true) &&
             in_array($demand->getSortByDirection(), $allowedSortByDirectionValues, true)
         ) {

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -54,24 +54,24 @@
                 <target>Listen Seite</target>
             </trans-unit>
             <trans-unit id="flexform.el.groupBy.label">
-                <source>Group By (this setting will override the sorting settings)</source>
-                <target>Gruppieren nach (diese Einstellung wird die Sortiereinstellungen überschreiben)</target>
+                <source>Group By (is given priority in sorting if activ)</source>
+                <target>Gruppieren nach (wird vorrangig bei der Sortierung berücksichtigt)</target>
             </trans-unit>
             <trans-unit id="flexform.el.groupBy.items.none">
                 <source>No grouping</source>
                 <target>Keine Gruppierung</target>
             </trans-unit>
             <trans-unit id="flexform.el.groupBy.items.first_name">
-                <source>First Name</source>
-                <target>Vorname</target>
+                <source>First Letter of First Name</source>
+                <target>Erster Buchstabe des Vornamens</target>
             </trans-unit>
             <trans-unit id="flexform.el.groupBy.items.last_name">
-                <source>Last Name</source>
-                <target>Nachname</target>
+                <source>First Letter of Last Name</source>
+                <target>Erster Buchstabe des Nachnamens</target>
             </trans-unit>
             <trans-unit id="flexform.el.sortBy.label">
-                <source>Sort By (will be ignored if grouping is active)</source>
-                <target>Sortieren nach (wird ignoriert, wenn die Gruppierung aktiv ist)</target>
+                <source>Sort By (sorting of activated grouping has priority)</source>
+                <target>Sortieren nach (wird nachrangig bei aktivierter Gruppierung berücksichtigt)</target>
             </trans-unit>
             <trans-unit id="flexform.el.sortBy.items.none">
                 <source>No sorting</source>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -42,19 +42,19 @@
                 <source>List Page</source>
             </trans-unit>
             <trans-unit id="flexform.el.groupBy.label">
-                <source>Group By (this setting will override the sorting settings)</source>
+                <source>Group By (is given priority in sorting if activ)</source>
             </trans-unit>
             <trans-unit id="flexform.el.groupBy.items.none">
                 <source>No grouping</source>
             </trans-unit>
             <trans-unit id="flexform.el.groupBy.items.first_name">
-                <source>First Name</source>
+                <source>First Letter of First Name</source>
             </trans-unit>
             <trans-unit id="flexform.el.groupBy.items.last_name">
-                <source>Last Name</source>
+                <source>First Letter of Last Name</source>
             </trans-unit>
             <trans-unit id="flexform.el.sortBy.label">
-                <source>Sort By (will be ignored if grouping is active)</source>
+                <source>Sort By (sorting of activated grouping has priority)</source>
             </trans-unit>
             <trans-unit id="flexform.el.sortBy.items.none">
                 <source>No sorting</source>
@@ -88,6 +88,9 @@
             </trans-unit>
             <trans-unit id="flexform.el.profileList.label">
                 <source>List of profiles</source>
+            </trans-unit>
+            <trans-unit id="flexform.el.fallbackForNonTranslated.label">
+                <source>Fallback to default language for non translated profiles</source>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -89,9 +89,6 @@
             <trans-unit id="flexform.el.profileList.label">
                 <source>List of profiles</source>
             </trans-unit>
-            <trans-unit id="flexform.el.fallbackForNonTranslated.label">
-                <source>Fallback to default language for non translated profiles</source>
-            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
If grouping for profile listing was active, sorting was only done by the grouping parameter. This lead to inconsistant output within the group as profiles were only sorted by the first letter of their first or last name.
Keep in mind, that the current solution is still not optimal, as an editor can set a grouping by last name and a sorting by first name or vice versa, which will also produce a strange output.