### PR TITLE
Add switch for language overlay mode

### DIFF
--- a/Classes/Controller/ProfileController.php
+++ b/Classes/Controller/ProfileController.php
@@ -38,13 +38,25 @@ final class ProfileController extends ActionController
 
     public function initializeAction(): void
     {
+        $context = GeneralUtility::makeInstance(Context::class);
+        $querySettings = new Typo3QuerySettings($context, $this->configurationManager);
+
         $contentObjectData = $this->configurationManager->getContentObject()?->data;
-        if (is_array($contentObjectData) && !empty($contentObjectData['pages'])) {
-            $context = GeneralUtility::makeInstance(Context::class);
-            $querySettings = new Typo3QuerySettings($context, $this->configurationManager);
-            $querySettings->setStoragePageIds(GeneralUtility::intExplode(',', $contentObjectData['pages']));
-            $this->profileRepository->setDefaultQuerySettings($querySettings);
+        if (is_array($contentObjectData)
+            && !empty($contentObjectData['pages'])
+        ) {
+            $querySettings->setStoragePageIds(
+                GeneralUtility::intExplode(',', $contentObjectData['pages'])
+            );
         }
+
+        if (isset($this->settings['fallbackForNonTranslated']) 
+            & (int)$this->settings['fallbackForNonTranslated'] === 1
+        ) {
+            $querySettings->setLanguageOverlayMode(true);
+        }
+
+        $this->profileRepository->setDefaultQuerySettings($querySettings);
     }
 
     public function initializeListAction(): void

--- a/Configuration/FlexForms/flexform_profile_list.xml
+++ b/Configuration/FlexForms/flexform_profile_list.xml
@@ -122,6 +122,23 @@
                             </config>
                         </TCEforms>
                     </settings.demand.profileList>
+                    <settings.fallbackForNonTranslated>
+                        <TCEforms>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.fallbackForNonTranslated.label</label>
+                            <config>
+                                <type>check</type>
+                                <renderType>checkboxToggle</renderType>
+                                <items>
+                                    <numIndex index="0" type="array">
+                                        <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.fallbackForNonTranslated.items.0.label</numIndex>
+                                        <labelChecked>Enabled</labelChecked>
+                                        <labelUnchecked>Disabled</labelUnchecked>
+                                    </numIndex>
+                                </items>
+                                <default>1</default>
+                            </config>
+                        </TCEforms>
+                    </settings.fallbackForNonTranslated>
                 </el>
             </ROOT>
         </sDEF>

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -117,6 +117,10 @@
                 <source>List of profiles</source>
                 <target>Liste von Profilen</target>
             </trans-unit>
+            <trans-unit id="flexform.el.fallbackForNonTranslated.label">
+                <source>Fallback to default language for non translated profiles</source>
+                <target>Fallback auf die Standardsprache für nicht übersetzte Profile</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -89,6 +89,9 @@
             <trans-unit id="flexform.el.profileList.label">
                 <source>List of profiles</source>
             </trans-unit>
+            <trans-unit id="flexform.el.fallbackForNonTranslated.label">
+                <source>Fallback to default language for non translated profiles</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
This PRs introduces a new FlexForm setting to enable language overlay mode for the profil repository to fall back to profile in default language if no translation was found.