### PR TITLE
Add FlexForm switch for alphabetical pagination

### DIFF
--- a/Configuration/FlexForms/flexform_profile_list.xml
+++ b/Configuration/FlexForms/flexform_profile_list.xml
@@ -87,6 +87,22 @@
                             </config>
                         </TCEforms>
                     </settings.paginationEnabled>
+                    <settings.alphabetPaginationEnabled>
+                        <TCEforms>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.alphabetPaginationEnabled.label</label>
+                            <config>
+                                <type>check</type>
+                                <renderType>checkboxToggle</renderType>
+                                <items>
+                                    <numIndex index="0" type="array">
+                                        <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.alphabetPaginationEnabled.items.0.label</numIndex>
+                                        <labelChecked>Enabled</labelChecked>
+                                        <labelUnchecked>Disabled</labelUnchecked>
+                                    </numIndex>
+                                </items>
+                            </config>
+                        </TCEforms>
+                    </settings.alphabetPaginationEnabled>
                     <settings.pagination.resultsPerPage>
                         <TCEforms>
                             <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.resultsPerPage.label</label>

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -75,7 +75,7 @@
             </trans-unit>
             <trans-unit id="flexform.el.sortBy.items.none">
                 <source>No sorting</source>
-                <target>Keine Gruppierung</target>
+                <target>Keine Sortierung</target>
             </trans-unit>
             <trans-unit id="flexform.el.sortBy.items.first_name">
                 <source>First Name</source>
@@ -97,9 +97,21 @@
                 <source>Descending</source>
                 <target>Absteigend</target>
             </trans-unit>
+            <trans-unit id="flexform.el.alphabetPaginationEnabled.label">
+                <source>Alphabetical Pagination</source>
+                <target>Alphabetische Paginierung</target>
+            </trans-unit>
+            <trans-unit id="flexform.el.alphabetPaginationEnabled.items.0.label">
+                <source>Enabled</source>
+                <target>Aktiviert</target>
+            </trans-unit>
             <trans-unit id="flexform.el.paginationEnabled.label">
                 <source>Pagination</source>
                 <target>Paginierung</target>
+            </trans-unit>
+            <trans-unit id="flexform.el.paginationEnabled.items.0.label">
+                <source>Enabled</source>
+                <target>Aktiviert</target>
             </trans-unit>
             <trans-unit id="flexform.el.resultsPerPage.label">
                 <source>Results per Page</source>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -74,17 +74,23 @@
             <trans-unit id="flexform.el.sortByDirection.items.desc">
                 <source>Descending</source>
             </trans-unit>
+            <trans-unit id="flexform.el.alphabetPaginationEnabled.label">
+                <source>Alphabetical Pagination</source>
+            </trans-unit>
+            <trans-unit id="flexform.el.alphabetPaginationEnabled.items.0.label">
+                <source>Enabled</source>
+            </trans-unit>
             <trans-unit id="flexform.el.paginationEnabled.label">
                 <source>Pagination</source>
+            </trans-unit>
+            <trans-unit id="flexform.el.paginationEnabled.items.0.label">
+                <source>Enabled</source>
             </trans-unit>
             <trans-unit id="flexform.el.resultsPerPage.label">
                 <source>Results per Page</source>
             </trans-unit>
             <trans-unit id="flexform.el.numberOfLinks.label">
                 <source>Number of Links</source>
-            </trans-unit>
-            <trans-unit id="flexform.el.paginationEnabled.items.0.label">
-                <source>Enabled</source>
             </trans-unit>
             <trans-unit id="flexform.el.profileList.label">
                 <source>List of profiles</source>


### PR DESCRIPTION
This PR adds a switch for the alphabetical pagination. The setting can be used as condition in list templates to make the output of the alphabetical pagination optional.