### PR TITLE
Apply sorting to selected profiles

### DIFF
--- a/Classes/Controller/ProfileController.php
+++ b/Classes/Controller/ProfileController.php
@@ -89,6 +89,20 @@ final class ProfileController extends ActionController
             ]);
         }
 
+        // If profiles were selected manually, sort them by order in selection
+        if (!empty($this->settings['demand']['profileList'])) {
+            $selectedProfiles = [];
+            $profileUidArray = GeneralUtility::intExplode(',', $this->settings['demand']['profileList'], true);
+            foreach($profileUidArray as $uid) {
+                foreach($profiles as $profile) {
+                    if ($profile->getUid() === $uid) {
+                        $selectedProfiles[] = $profile;
+                    }
+                }
+            }
+            $profiles = $selectedProfiles;
+        }
+
         $this->view->assignMultiple([
             'data' => $this->configurationManager->getContentObject()?->data,
             'profiles' => $profiles,

--- a/Classes/Domain/Repository/ProfileRepository.php
+++ b/Classes/Domain/Repository/ProfileRepository.php
@@ -60,7 +60,10 @@ class ProfileRepository extends Repository
         if ($filters !== null) {
             $query->matching($filters);
         }
-        $query->setOrderings($this->getOrderingsFromDemand($demand));
+
+        if (empty($demand->getProfileList())) {
+            $query->setOrderings($this->getOrderingsFromDemand($demand));
+        }
     }
 
     /**


### PR DESCRIPTION
If profiles are selected manually in the plugin their order in the selection should be preserved. Therefore sorting settings get ignored by the repository and the selected profiles are sorted afterwards in the controller. Technically sorting in the controller ist not the best solution, but it seems the most suiteable one (see also https://github.com/georgringer/news/blob/80ced4c3cf24fb287c35d961f7eb41feba6c0676/Classes/Controller/NewsController.php#L325).