### PR TITLE
Deactivate storage PID handling

### DIFF
--- a/Classes/Controller/ProfileController.php
+++ b/Classes/Controller/ProfileController.php
@@ -48,6 +48,8 @@ final class ProfileController extends ActionController
             $querySettings->setStoragePageIds(
                 GeneralUtility::intExplode(',', $contentObjectData['pages'])
             );
+        } else {
+            $querySettings->setRespectStoragePage(false);
         }
 
         if (isset($this->settings['fallbackForNonTranslated']) 


### PR DESCRIPTION
Deactivate storage PID handling if storage PIDs are not explicitly defined in the plugin settings. This follows the behavior of extensions like news.