### PR TITLE
[TASK] Minor tooling streamlining

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 /var
 
 /.php-cs-fixer.cache
+/composer.json.original
+/composer.json.testing
 /composer.lock
 
 /Documentation-GENERATED-temp

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -105,10 +105,9 @@ Options:
             - mysql: use mysql
             - postgres: use postgres
 
-    -p <7.4|8.0|8.1|8.2>
+    -p <|8.0|8.1|8.2>
         Specifies the PHP minor version to be used
-            - 7.4 (default): use PHP 7.4
-            - 8.0: use PHP 8.0
+            - 8.0: use PHP 8.0 (default)
             - 8.1: use PHP 8.1
             - 8.2: use PHP 8.2
 
@@ -147,7 +146,7 @@ Options:
         Show this help.
 
 Examples:
-    # Run unit tests using PHP 7.4
+    # Run unit tests using PHP 8.0
     ./Build/Scripts/runTests.sh -s unit
 EOF
 
@@ -191,7 +190,7 @@ else
 fi
 TEST_SUITE=""
 DBMS="sqlite"
-PHP_VERSION="7.4"
+PHP_VERSION="8.0"
 TYPO3_VERSION="11"
 PHP_XDEBUG_ON=0
 EXTRA_TEST_OPTIONS=""
@@ -219,7 +218,7 @@ while getopts ":s:a:d:p:t:e:xnhuv" OPT; do
             ;;
         p)
             PHP_VERSION=${OPTARG}
-            if ! [[ ${PHP_VERSION} =~ ^(7.4|8.0|8.1|8.2)$ ]]; then
+            if ! [[ ${PHP_VERSION} =~ ^(8.0|8.1|8.2)$ ]]; then
                 INVALID_OPTIONS+=("p ${OPTARG}")
             fi
             ;;

--- a/Classes/Domain/Model/Address.php
+++ b/Classes/Domain/Model/Address.php
@@ -11,8 +11,6 @@ declare(strict_types=1);
 
 namespace Fgtclb\AcademicPersons\Domain\Model;
 
-use Fgtclb\AcademicPersons\Domain\Model\FunctionType;
-use Fgtclb\AcademicPersons\Domain\Model\OrganisationalUnit;
 use TYPO3\CMS\Extbase\Annotation\Validate;
 use TYPO3\CMS\Extbase\Domain\Model\Category;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;

--- a/Classes/Domain/Model/Contract.php
+++ b/Classes/Domain/Model/Contract.php
@@ -263,18 +263,18 @@ class Contract extends AbstractEntity
         $firstName = '-';
         $lastName = '-';
         if ($this->profile !== null) {
-            $firstName = $this->profile->getLastName() ?? '-';
-            $lastName = $this->profile->getFirstName() ?? '-';
+            $firstName = $this->profile->getLastName() ?: '-';
+            $lastName = $this->profile->getFirstName() ?: '-';
         }
 
         $functionType = '-';
         if ($this->functionType !== null) {
-            $functionType = $this->functionType->getFunctionName() ?? '-';
+            $functionType = $this->functionType->getFunctionName() ?: '-';
         }
 
         $organisationalUnit = '-';
         if ($this->organisationalUnit !== null) {
-            $organisationalUnit = $this->organisationalUnit->getUnitName() ?? '-';
+            $organisationalUnit = $this->organisationalUnit->getUnitName() ?: '-';
         }
 
         $validFrom = $this->validFrom ? $this->validFrom->format('Y-m-d') : '-';

--- a/Classes/Domain/Model/Contract.php
+++ b/Classes/Domain/Model/Contract.php
@@ -12,13 +12,6 @@ declare(strict_types=1);
 namespace Fgtclb\AcademicPersons\Domain\Model;
 
 use DateTime;
-use Fgtclb\AcademicPersons\Domain\Model\Address;
-use Fgtclb\AcademicPersons\Domain\Model\Email;
-use Fgtclb\AcademicPersons\Domain\Model\FunctionType;
-use Fgtclb\AcademicPersons\Domain\Model\Location;
-use Fgtclb\AcademicPersons\Domain\Model\OrganisationalUnit;
-use Fgtclb\AcademicPersons\Domain\Model\PhoneNumber;
-use Fgtclb\AcademicPersons\Domain\Model\Profile;
 use TYPO3\CMS\Extbase\Annotation\ORM\Cascade;
 use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
 use TYPO3\CMS\Extbase\Domain\Model\Category;

--- a/Classes/Domain/Model/OrganisationalUnit.php
+++ b/Classes/Domain/Model/OrganisationalUnit.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Fgtclb\AcademicPersons\Domain\Model;
 
 use DateTime;
-use Fgtclb\AcademicPersons\Domain\Model\Contract;
 use TYPO3\CMS\Extbase\Annotation\ORM\Cascade;
 use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
 use TYPO3\CMS\Extbase\Annotation\Validate;

--- a/Classes/Domain/Model/Profile.php
+++ b/Classes/Domain/Model/Profile.php
@@ -11,8 +11,6 @@ declare(strict_types=1);
 
 namespace Fgtclb\AcademicPersons\Domain\Model;
 
-use Fgtclb\AcademicPersons\Domain\Model\Contract;
-use Fgtclb\AcademicPersons\Domain\Model\ProfileInformation;
 use TYPO3\CMS\Extbase\Annotation\ORM\Cascade;
 use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
 use TYPO3\CMS\Extbase\Annotation\Validate;


### PR DESCRIPTION
- **[TASK] Align `runTests.sh` with `composer.json`**
  Public extension should support the whole PHP version range
  for all supported TYPO3 versions, already violated with the
  used root composer.json constraint of `"php: "^8.0`.
  
  It does not make much sense to keep the command execeution
  wrapper `Build/Scripts/runTests.sh` on PHP 7.4 as default
  version, beside supporting a version not supported by the
  composer.json at all.
  
  This change streamlines `Build/Scripts/runTests.sh` and
  removes `PHP 7.4` as allowed PHP version and set default
  used PHP version to 8.0.
  
  Additionally, temporary composer.json copies created and
  used by `runTests.sh` are added to `.gitignore`.
  
  Note docker-compose based `runTests.sh` should be replaced
  with podman/docker tooling variant instead to adopt TYPO3
  devlopment of the last ~1.5 years in this regard.
  

- **[TASK] Remove unused imports**
  This extension has `cgl` guard in place using the
  `php-cs-fixer` tooling, which seems to have been
  ignored in the work in the past.
  
  Some PHP code files containes unused php namespace
  imports, which is forbidden by the used cgl rules.
  
  This change removes the unused php namespace imports
  by applying php-cs-fixer changes.
  
  Used command(s):
  
  ```shell
  Build/Scripts/runTests.sh -t 11 -p 8.0 -s cgl
  ```
  
- **[BUGFIX] Use appropiated fallback handling in model Contract**
  The extbase model `Contract` called getter methods on
  referenced models, which got not-nullable return types
  meanwhile rendering used null-coalsce operator fallbacks
  use-less.

  This is detected by the used static code-analyzer and
  reported correctly.

  This change replaces used null-coalsce operators fallbacks
  in these cases with a simplified tenary fallback to set
  default value if empty strings are returned instead of reacting
  on null.

  No need to update PHPStan baseline due to aligning code.
