### PR TITLE
[TASK] Cover frontend plugins by adding functional tests

### DIFF
--- a/Build/phpstan/Core11/phpstan-baseline.neon
+++ b/Build/phpstan/Core11/phpstan-baseline.neon
@@ -1,6 +1,2 @@
 parameters:
 	ignoreErrors:
-		-
-			message: "#^Variable \\$_EXTKEY might not be defined\\.$#"
-			count: 1
-			path: ../../../ext_emconf.php

--- a/Build/phpstan/Core11/phpstan.neon
+++ b/Build/phpstan/Core11/phpstan.neon
@@ -9,7 +9,8 @@ parameters:
 	level: 8
 
 	paths:
-		- ../../../
+		- ../../../Classes
+		- ../../../Tests/
 
 	excludePaths:
 		# ext_emconf.php get the $_EXTKEY set from outsite. We'll ignore all of them

--- a/Build/phpstan/Core11/phpstan.neon
+++ b/Build/phpstan/Core11/phpstan.neon
@@ -12,6 +12,10 @@ parameters:
 		- ../../../
 
 	excludePaths:
+		# ext_emconf.php get the $_EXTKEY set from outsite. We'll ignore all of them
+		- ../../../ext_emconf.php
+		- ../../../Tests/Functional/Fixtures/Extensions/*/ext_emconf.php
+		# Build and cache folders
 		- ../../../.Build
 		- ../../../.cache
 		- ../../../Build

--- a/Build/phpstan/Core12/phpstan-baseline.neon
+++ b/Build/phpstan/Core12/phpstan-baseline.neon
@@ -1,6 +1,2 @@
 parameters:
 	ignoreErrors:
-		-
-			message: "#^Variable \\$_EXTKEY might not be defined\\.$#"
-			count: 1
-			path: ../../../ext_emconf.php

--- a/Build/phpstan/Core12/phpstan.neon
+++ b/Build/phpstan/Core12/phpstan.neon
@@ -13,6 +13,10 @@ parameters:
 		- ../../../Tests/
 
 	excludePaths:
+		# ext_emconf.php get the $_EXTKEY set from outsite. We'll ignore all of them
+		- ../../../ext_emconf.php
+		- ../../../Tests/Functional/Fixtures/Extensions/*/ext_emconf.php
+		# Build and cache folders
 		- ../../../.Build
 		- ../../../Tests/Functional/Updates/Fixtures/Extension/test_extension/ext_emconf.php
 		- ../../../Classes/Override/Core11

--- a/Build/phpunit/FunctionalTestsBootstrap.php
+++ b/Build/phpunit/FunctionalTestsBootstrap.php
@@ -27,4 +27,16 @@
     $testbase->defineOriginalRootPath();
     $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/tests');
     $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/transient');
+
+    // Iterate over all fixture extensions and register them to allow the composer
+    // package name to be used in functional tests as `$testExtensionToLoad`.
+    $composerPackageManager = (new \TYPO3\TestingFramework\Composer\ComposerPackageManager());
+    $iterator = new \DirectoryIterator($composerPackageManager->getRootPath() . '/Tests/Functional/Fixtures/Extensions');
+    /** @var \SplFileInfo $info */
+    foreach ($iterator as $info) {
+        if ($info->isDot() || !$info->isDir()) {
+            continue;
+        }
+        $composerPackageManager->getPackageInfoWithFallback($info->getPathname());
+    }
 })();

--- a/Classes/Controller/ProfileController.php
+++ b/Classes/Controller/ProfileController.php
@@ -52,9 +52,10 @@ final class ProfileController extends ActionController
             $querySettings->setRespectStoragePage(false);
         }
 
-        if (isset($this->settings['fallbackForNonTranslated'])
-            && (int)$this->settings['fallbackForNonTranslated'] === 1
-        ) {
+        // Introduced with https://github.com/fgtclb/academic-persons/pull/30 to have the option to display profiles in
+        // fallback mode even when site language (non-default) is configured to be in strict mode.
+        // See: AcademicPersonsListPluginTest::fullyLocalizedPagesAndTtContentListDisplaysOnlyLocalizedProfilesForRequestedLanguageWithNotAllProfilesLocalizedInStrictModeWithFallbackForNonTranslatedSet()
+        if ((int)($this->settings['fallbackForNonTranslated'] ?? 0) === 1) {
             $querySettings->setLanguageOverlayMode(true);
         }
 

--- a/Tests/Functional/Fixtures/Extensions/test_plugin_templates/Configuration/TypoScript/constants.typoscript
+++ b/Tests/Functional/Fixtures/Extensions/test_plugin_templates/Configuration/TypoScript/constants.typoscript
@@ -1,16 +1,4 @@
-@import 'EXT:academic_persons/Configuration/TypoScript/constants.typoscript'
-
 plugin.tx_academicpersons {
-  detailPid =
-  demand {
-    groupBy =
-    sortBy =
-    sortByDirection = asc
-  }
-  pagination {
-    resultsPerPage = 1
-    numberOfLinks = 5
-  }
   view {
     templateRootPath = EXT:test_plugin_templates/Resources/Private/Templates/
     partialRootPath = EXT:test_plugin_templates/Resources/Private/Partials/

--- a/Tests/Functional/Fixtures/Extensions/test_plugin_templates/Configuration/TypoScript/constants.typoscript
+++ b/Tests/Functional/Fixtures/Extensions/test_plugin_templates/Configuration/TypoScript/constants.typoscript
@@ -1,0 +1,19 @@
+@import 'EXT:academic_persons/Configuration/TypoScript/constants.typoscript'
+
+plugin.tx_academicpersons {
+  detailPid =
+  demand {
+    groupBy =
+    sortBy =
+    sortByDirection = asc
+  }
+  pagination {
+    resultsPerPage = 1
+    numberOfLinks = 5
+  }
+  view {
+    templateRootPath = EXT:test_plugin_templates/Resources/Private/Templates/
+    partialRootPath = EXT:test_plugin_templates/Resources/Private/Partials/
+    layoutRootPath = EXT:test_plugin_templates/Resources/Private/Layouts/
+  }
+}

--- a/Tests/Functional/Fixtures/Extensions/test_plugin_templates/Configuration/TypoScript/setup.typoscript
+++ b/Tests/Functional/Fixtures/Extensions/test_plugin_templates/Configuration/TypoScript/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:academic_persons/Configuration/TypoScript/setup.typoscript'

--- a/Tests/Functional/Fixtures/Extensions/test_plugin_templates/Resources/Private/Partials/List/ListItem.html
+++ b/Tests/Functional/Fixtures/Extensions/test_plugin_templates/Resources/Private/Partials/List/ListItem.html
@@ -1,0 +1,6 @@
+<html data-namespace-typo3-fluid="true"
+      xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+>
+<f:variable name="targetPlugin" value="{f:if(condition: '{settings.detailPid} > 0 && {settings.detailPid} != {data.pid}', then: 'Detail', else: 'ListAndDetail')}" />
+#{itemIterator.index}({profile.uid}): {profile.firstName}{f:if(condition: profile.middleName, then: ' {profile.middleName}')} {profile.lastName} LINK: "<f:uri.action pageUid="{settings.detailPid}" action="detail" pluginName="{targetPlugin}" arguments="{profile: profile}" />"
+</html>

--- a/Tests/Functional/Fixtures/Extensions/test_plugin_templates/Resources/Private/Templates/Profile/Detail.html
+++ b/Tests/Functional/Fixtures/Extensions/test_plugin_templates/Resources/Private/Templates/Profile/Detail.html
@@ -1,0 +1,151 @@
+<html data-namespace-typo3-fluid="true"
+      xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+>
+
+<h1>
+    {profile.firstName} {profile.lastName}
+</h1>
+<h2>Profiledetailpage</h2>
+<f:if condition="{profile.image}">
+    <f:image image="{profile.image}" maxWidth="500" maxHeight="500" alt="{profile.firstName} {profile.lastName}" />
+</f:if>
+
+<p>
+    <f:if condition="{profile.gender}">{profile.gender}</f:if>
+    <f:if condition="{profile.title}">{profile.title}</f:if>
+    #{profile.uid}: {profile.firstName}{f:if(condition: profile.middleName, then: ' {profile.middleName}')} {profile.lastName}
+</p>
+
+<h2>Contracts</h2>
+
+<f:for each="{profile.contracts}" as="contract">
+    Employee Type: {contract.employeeType.title}<br />
+    <br />
+    <h3>Contact</h3>
+    Position: {contract.position}<br />
+    Room: {contract.room}<br />
+    <br />
+    <h4>Addresses</h4>
+    <f:for each="{contract.physicalAddresses}" as="physicalAddress">
+        {physicalAddress.street} {physicalAddress.streetNumber}<br />
+        <f:if condition="{physicalAddress.additional}">{physicalAddress.additional}<br /></f:if>
+        {physicalAddress.zip} {physicalAddress.city}<br />
+        <f:if condition="{physicalAddress.state}">{physicalAddress.state}<br /></f:if>
+        <f:if condition="{physicalAddress.country}">{physicalAddress.country}</f:if><br />
+    </f:for>
+    <br />
+    <h4>Email address</h4>
+    <f:for each="{contract.emailAddresses}" as="emailAddress">
+        {emailAddress.email} ({emailAddress.type})<br />
+    </f:for>
+    <br />
+    <h4>Phone / Fax</h4>
+    <f:for each="{contract.phoneNumbers}" as="phoneNumber">
+        {phoneNumber.phoneNumber} ({phoneNumber.type})<br />
+    </f:for>
+</f:for>
+
+<h2>Additional Information</h2>
+
+<f:if condition="{profile.website} && {profile.websiteTitle}">
+  <f:then>
+    Website: <a href="{profile.website}" target="_blank">{profile.websiteTitle}</a>
+  </f:then>
+  <f:else>
+    Website: <a href="{profile.website}" target="_blank">{profile.website}</a>
+  </f:else>
+</f:if>
+
+<br />
+
+<h3>Teaching Area</h3>
+<f:format.html>{profile.teachingArea}</f:format.html>
+
+<h3>Main topics/core competencies</h3>
+<f:format.html>{profile.coreCompetences}</f:format.html>
+
+<f:if condition="{profile.memberships}">
+    <h3>Offices/committees/memberships</h3>
+    <f:for each="{profile.memberships}" as="membership">
+        <h4>{membership.year}: {membership.title}</h4>
+        <p>{membership.bodytext -> f:format.nl2br()}</p>
+        <f:if condition="{membership.link}">
+            <p>
+                <f:link.external uri="{membership.link}">{membership.title}</f:link.external>
+            </p>
+        </f:if>
+    </f:for>
+</f:if>
+
+<f:if condition="{profile.supervisedThesis}">
+    <h3>Supervised theses</h3>
+    <f:format.html>{profile.supervisedThesis}</f:format.html>
+</f:if>
+
+<f:if condition="{profile.supervisedDoctoralThesis}">
+    <h3>Supervised doctoral theses</h3>
+    <f:format.html>{profile.supervisedDoctoralThesis}</f:format.html>
+</f:if>
+
+<f:if condition="{profile.vita}">
+    <h3>Vita</h3>
+    <f:for each="{profile.vita}" as="vita">
+        <h4>{vita.year}: {vita.title}</h4>
+        <p>{vita.bodytext -> f:format.nl2br()}</p>
+    </f:for>
+</f:if>
+
+<f:if condition="{profile.publications}">
+    <h3>Publications</h3>
+    <f:for each="{profile.publications}" as="publication">
+        <h4>{publication.year}: {publication.title}</h4>
+        <f:format.raw>{publication.bodytext}</f:format.raw>
+        <f:if condition="{publication.link} && ">
+            <p>
+                <f:link.external uri="{publication.link}">{publication.title}</f:link.external>
+            </p>
+        </f:if>
+    </f:for>
+</f:if>
+
+<f:if condition="{profile.publicationsLink} && {profile.publicationsLinkTitle}">
+	<f:then>
+    Link to publications: <a href="{profile.publicationsLink}" target="_blank">{profile.publicationsLinkTitle}</a>
+	</f:then>
+	<f:else>
+    Link to publications: <a href="{profile.publicationsLink}" target="_blank">{profile.publicationsLink}</a>
+	</f:else>
+</f:if>
+
+<f:if condition="{profile.miscellaneous}">
+    <h3>Miscellaneous information</h3>
+    <f:format.html>{profile.miscellaneous}</f:format.html>
+</f:if>
+
+<f:if condition="{profile.cooperation}">
+    <h3>Networks and Cooperation</h3>
+    <f:for each="{profile.cooperation}" as="cooperation">
+        <h4>{cooperation.year}: {cooperation.title}</h4>
+        <f:format.raw>{cooperation.bodytext}</f:format.raw>
+        <f:if condition="{cooperation.link}">
+            <p>
+                <f:link.external uri="{cooperation.link}">{cooperation.title}</f:link.external>
+            </p>
+        </f:if>
+    </f:for>
+</f:if>
+
+<f:if condition="{profile.lectures}">
+    <h3>Lectures</h3>
+    <f:for each="{profile.lectures}" as="lecture">
+        <h4>{lecture.year}: {lecture.title}</h4>
+        <f:format.raw>{lecture.bodytext}</f:format.raw>
+        <f:if condition="{lecture.link}">
+            <p>
+                <f:link.external uri="{lecture.link}">{lecture.title}</f:link.external>
+            </p>
+        </f:if>
+    </f:for>
+</f:if>
+
+</html>

--- a/Tests/Functional/Fixtures/Extensions/test_plugin_templates/Resources/Private/Templates/Profile/List.html
+++ b/Tests/Functional/Fixtures/Extensions/test_plugin_templates/Resources/Private/Templates/Profile/List.html
@@ -1,0 +1,37 @@
+<html data-namespace-typo3-fluid="true"
+      xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+>
+
+<f:if condition="{profiles}">
+    <f:variable name="profilesToList" value="{profiles}" />
+    <f:if condition="{settings.paginationEnabled}">
+        <f:variable name="profilesToList" value="{pagination.paginator.paginatedItems}" />
+    </f:if>
+
+    <f:if condition="{demand.groupBy}">
+        <f:then>
+            <f:groupedFor as="groupedProfiles" groupBy="{demand.groupBy}" each="{profilesToList}">
+                <h3>{groupKey}</h3>
+                <ul>
+                    <f:for each="{groupedProfiles}" as="profile">
+                        <f:render partial="List/ListItem" arguments="{profile: profile, demand: demand, settings: settings}" />
+                    </f:for>
+                </ul>
+            </f:groupedFor>
+        </f:then>
+        <f:else>
+<h2>Profilelist</h2>
+<pre>
+<f:for each="{profilesToList}" as="profile" iteration="itemIterator">
+<f:render partial="List/ListItem" arguments="{profile: profile, demand: demand, settings: settings, itemIterator: itemIterator}" />
+</f:for>
+</pre>
+        </f:else>
+    </f:if>
+
+    <f:if condition="{settings.paginationEnabled}">
+        <f:render partial="List/Pagination" arguments="{paginator: paginator, pagination: pagination}" />
+    </f:if>
+</f:if>
+
+</html>

--- a/Tests/Functional/Fixtures/Extensions/test_plugin_templates/composer.json
+++ b/Tests/Functional/Fixtures/Extensions/test_plugin_templates/composer.json
@@ -1,0 +1,22 @@
+{
+    "name": "tests/plugin-templates",
+    "description": "Plugin template overrides for tests",
+    "type": "typo3-cms-extension",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "Stefan Bürk",
+            "email": "stefan@buerk.tech",
+            "role": "Maintainer"
+        }
+    ],
+    "require": {
+        "typo3/cms-core": "*",
+		"fgtclb/academic-persons": "*"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "test_plugin_templates"
+        }
+    }
+}

--- a/Tests/Functional/Fixtures/Extensions/test_plugin_templates/ext_emconf.php
+++ b/Tests/Functional/Fixtures/Extensions/test_plugin_templates/ext_emconf.php
@@ -1,0 +1,23 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'TESTS: Academic Persons Plugin Templates',
+    'description' => 'Provide plugin template overrides for academic-persons for functional tests',
+    'category' => 'plugin',
+    'author' => 'Stefan Bürk',
+    'author_email' => 'stefan@buerk.tech',
+    'author_company' => 'web-vision GmbH',
+    'state' => 'beta',
+    'version' => '0.3.1',
+    'clearCacheOnLoad' => true,
+    'constraints' => [
+        'depends' => [
+            'typo3' => '*',
+            'academic_persons' => '*',
+        ],
+        'conflicts' => [
+        ],
+        'suggests' => [
+        ],
+    ],
+];

--- a/Tests/Functional/Fixtures/Frontend/FluidError.html
+++ b/Tests/Functional/Fixtures/Frontend/FluidError.html
@@ -1,0 +1,3 @@
+uri: {request.uri}
+message: {message}
+reasons: <f:for each="{reasons}" as="reason" key="key">{key},</f:for>

--- a/Tests/Functional/Fixtures/Frontend/FluidJson.html
+++ b/Tests/Functional/Fixtures/Frontend/FluidJson.html
@@ -1,0 +1,1 @@
+{results -> f:format.json() -> f:format.raw()}

--- a/Tests/Functional/Fixtures/Frontend/PageError.txt
+++ b/Tests/Functional/Fixtures/Frontend/PageError.txt
@@ -1,0 +1,2 @@
+url: ###CURRENT_URL###
+reason: ###REASON###

--- a/Tests/Functional/Fixtures/Frontend/PhpError.php
+++ b/Tests/Functional/Fixtures/Frontend/PhpError.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\CMS\Core\Tests\Functional\Fixtures\Frontend;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Error\PageErrorHandler\PageErrorHandlerInterface;
+use TYPO3\CMS\Core\Http\JsonResponse;
+
+/**
+ * Test case for frontend requests without having site handling configured
+ */
+class PhpError implements PageErrorHandlerInterface
+{
+    /**
+     * @var int
+     */
+    private $statusCode;
+
+    /**
+     * @param int $statusCode
+     */
+    public function __construct(int $statusCode)
+    {
+        $this->statusCode = $statusCode;
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     * @param string $message
+     * @param string[] $reasons
+     * @return ResponseInterface
+     */
+    public function handlePageError(
+        ServerRequestInterface $request,
+        string $message,
+        array $reasons = []
+    ): ResponseInterface {
+        $data = [
+            'uri' => (string)$request->getUri(),
+            'message' => $message,
+            'reasons' => $reasons,
+        ];
+        return new JsonResponse($data, $this->statusCode);
+    }
+}

--- a/Tests/Functional/Fixtures/Trait/SiteBasedTestTrait.php
+++ b/Tests/Functional/Fixtures/Trait/SiteBasedTestTrait.php
@@ -35,7 +35,7 @@ use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
 trait SiteBasedTestTrait
 {
     /**
-     * @param array $items
+     * @param string[] $items
      */
     protected static function failIfArrayIsNotEmpty(array $items): void
     {
@@ -51,9 +51,9 @@ trait SiteBasedTestTrait
 
     /**
      * @param string $identifier
-     * @param array $site
-     * @param array $languages
-     * @param array $errorHandling
+     * @param array<string, mixed> $site
+     * @param list<array<string, mixed>> $languages
+     * @param array<string, mixed> $errorHandling
      */
     protected function writeSiteConfiguration(
         string $identifier,
@@ -84,7 +84,7 @@ trait SiteBasedTestTrait
 
     /**
      * @param string $identifier
-     * @param array $overrides
+     * @param array<string, mixed> $overrides
      */
     protected function mergeSiteConfiguration(
         string $identifier,
@@ -106,7 +106,7 @@ trait SiteBasedTestTrait
     /**
      * @param int $rootPageId
      * @param string $base
-     * @return array
+     * @return array<string, mixed>
      */
     protected function buildSiteConfiguration(
         int $rootPageId,
@@ -121,7 +121,7 @@ trait SiteBasedTestTrait
     /**
      * @param string $identifier
      * @param string $base
-     * @return array
+     * @return array<string, mixed>
      */
     protected function buildDefaultLanguageConfiguration(
         string $identifier,
@@ -137,9 +137,9 @@ trait SiteBasedTestTrait
     /**
      * @param string $identifier
      * @param string $base
-     * @param array $fallbackIdentifiers
+     * @param array<int, string> $fallbackIdentifiers
      * @param string $fallbackType
-     * @return array
+     * @return array<string, mixed>
      */
     protected function buildLanguageConfiguration(
         string $identifier,
@@ -180,8 +180,8 @@ trait SiteBasedTestTrait
 
     /**
      * @param string $handler
-     * @param array $codes
-     * @return array
+     * @param int[] $codes
+     * @return array<string, mixed>
      */
     protected function buildErrorHandlingConfiguration(
         string $handler,
@@ -257,11 +257,9 @@ trait SiteBasedTestTrait
 
         foreach ($instructions as $instruction) {
             $identifier = $instruction->getIdentifier();
-            if (isset($modifiedInstructions[$identifier]) || $request->getInstruction($identifier) !== null) {
-                $modifiedInstructions[$identifier] = $this->mergeInstruction(
-                    $modifiedInstructions[$identifier] ?? $request->getInstruction($identifier),
-                    $instruction
-                );
+            $useModifier = $modifiedInstructions[$identifier] ?? $request->getInstruction($identifier);
+            if ($useModifier !== null) {
+                $modifiedInstructions[$identifier] = $this->mergeInstruction($useModifier, $instruction);
             } else {
                 $modifiedInstructions[$identifier] = $instruction;
             }

--- a/Tests/Functional/Fixtures/Trait/SiteBasedTestTrait.php
+++ b/Tests/Functional/Fixtures/Trait/SiteBasedTestTrait.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Fgtclb\AcademicPersons\Tests\Functional\Fixtures\Trait;
+
+use TYPO3\CMS\Core\Configuration\SiteConfiguration;
+use TYPO3\CMS\Core\Tests\Functional\Fixtures\Frontend\PhpError;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Internal\AbstractInstruction;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Internal\ArrayValueInstruction;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Internal\TypoScriptInstruction;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+
+/**
+ * Trait used for test classes that want to set up (= write) site configuration files.
+ *
+ * Mainly used when testing Site-related tests in Frontend requests.
+ *
+ * Be sure to set the LANGUAGE_PRESETS const in your class.
+ */
+trait SiteBasedTestTrait
+{
+    /**
+     * @param array $items
+     */
+    protected static function failIfArrayIsNotEmpty(array $items): void
+    {
+        if (empty($items)) {
+            return;
+        }
+
+        static::fail(
+            'Array was not empty as expected, but contained these items:' . LF
+            . '* ' . implode(LF . '* ', $items)
+        );
+    }
+
+    /**
+     * @param string $identifier
+     * @param array $site
+     * @param array $languages
+     * @param array $errorHandling
+     */
+    protected function writeSiteConfiguration(
+        string $identifier,
+        array $site = [],
+        array $languages = [],
+        array $errorHandling = []
+    ): void {
+        $configuration = $site;
+        if (!empty($languages)) {
+            $configuration['languages'] = $languages;
+        }
+        if (!empty($errorHandling)) {
+            $configuration['errorHandling'] = $errorHandling;
+        }
+        $siteConfiguration = new SiteConfiguration(
+            $this->instancePath . '/typo3conf/sites/',
+            $this->get('cache.core')
+        );
+
+        try {
+            // ensure no previous site configuration influences the test
+            GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites/' . $identifier, true);
+            $siteConfiguration->write($identifier, $configuration);
+        } catch (\Exception $exception) {
+            $this->markTestSkipped($exception->getMessage());
+        }
+    }
+
+    /**
+     * @param string $identifier
+     * @param array $overrides
+     */
+    protected function mergeSiteConfiguration(
+        string $identifier,
+        array $overrides
+    ): void {
+        $siteConfiguration = new SiteConfiguration(
+            $this->instancePath . '/typo3conf/sites/',
+            $this->get('cache.core')
+        );
+        $configuration = $siteConfiguration->load($identifier);
+        $configuration = array_merge($configuration, $overrides);
+        try {
+            $siteConfiguration->write($identifier, $configuration);
+        } catch (\Exception $exception) {
+            $this->markTestSkipped($exception->getMessage());
+        }
+    }
+
+    /**
+     * @param int $rootPageId
+     * @param string $base
+     * @return array
+     */
+    protected function buildSiteConfiguration(
+        int $rootPageId,
+        string $base = ''
+    ): array {
+        return [
+            'rootPageId' => $rootPageId,
+            'base' => $base,
+        ];
+    }
+
+    /**
+     * @param string $identifier
+     * @param string $base
+     * @return array
+     */
+    protected function buildDefaultLanguageConfiguration(
+        string $identifier,
+        string $base
+    ): array {
+        $configuration = $this->buildLanguageConfiguration($identifier, $base);
+        $configuration['typo3Language'] = 'default';
+        $configuration['flag'] = 'global';
+        unset($configuration['fallbackType'], $configuration['fallbacks']);
+        return $configuration;
+    }
+
+    /**
+     * @param string $identifier
+     * @param string $base
+     * @param array $fallbackIdentifiers
+     * @param string $fallbackType
+     * @return array
+     */
+    protected function buildLanguageConfiguration(
+        string $identifier,
+        string $base,
+        array $fallbackIdentifiers = [],
+        ?string $fallbackType = null
+    ): array {
+        $preset = $this->resolveLanguagePreset($identifier);
+
+        $configuration = [
+            'languageId' => $preset['id'],
+            'title' => $preset['title'],
+            'navigationTitle' => $preset['title'],
+            'base' => $base,
+            'locale' => $preset['locale'],
+            'iso-639-1' => $preset['iso'] ?? '',
+            'hreflang' => $preset['hrefLang'] ?? '',
+            'direction' => $preset['direction'] ?? '',
+            'typo3Language' => $preset['iso'] ?? '',
+            'flag' => $preset['iso'] ?? '',
+            'fallbackType' => $fallbackType ?? (empty($fallbackIdentifiers) ? 'strict' : 'fallback'),
+        ];
+
+        if (!empty($fallbackIdentifiers)) {
+            $fallbackIds = array_map(
+                function (string $fallbackIdentifier) {
+                    $preset = $this->resolveLanguagePreset($fallbackIdentifier);
+                    return $preset['id'];
+                },
+                $fallbackIdentifiers
+            );
+            $configuration['fallbackType'] = $fallbackType ?? 'fallback';
+            $configuration['fallbacks'] = implode(',', $fallbackIds);
+        }
+
+        return $configuration;
+    }
+
+    /**
+     * @param string $handler
+     * @param array $codes
+     * @return array
+     */
+    protected function buildErrorHandlingConfiguration(
+        string $handler,
+        array $codes
+    ): array {
+        if ($handler === 'Page') {
+            // This implies you cannot test both 404 and 403 in the same test.
+            // Fixing that requires much deeper changes to the testing harness,
+            // as the structure here is only a portion of the config array structure.
+            if (in_array(404, $codes, true)) {
+                $baseConfiguration = [
+                    'errorContentSource' => 't3://page?uid=404',
+                ];
+            } elseif (in_array(403, $codes, true)) {
+                $baseConfiguration = [
+                    'errorContentSource' => 't3://page?uid=403',
+                ];
+            }
+        } elseif ($handler === 'Fluid') {
+            $baseConfiguration = [
+                'errorFluidTemplate' => 'typo3/sysext/core/Tests/Functional/Fixtures/Frontend/FluidError.html',
+                'errorFluidTemplatesRootPath' => '',
+                'errorFluidLayoutsRootPath' => '',
+                'errorFluidPartialsRootPath' => '',
+            ];
+        } elseif ($handler === 'PHP') {
+            $baseConfiguration = [
+                'errorPhpClassFQCN' => PhpError::class,
+            ];
+        } else {
+            throw new \LogicException(
+                sprintf('Invalid handler "%s"', $handler),
+                1533894782
+            );
+        }
+
+        $baseConfiguration['errorHandler'] = $handler;
+
+        return array_map(
+            static function (int $code) use ($baseConfiguration) {
+                $baseConfiguration['errorCode'] = $code;
+                return $baseConfiguration;
+            },
+            $codes
+        );
+    }
+
+    /**
+     * @param string $identifier
+     * @return mixed
+     */
+    protected function resolveLanguagePreset(string $identifier)
+    {
+        if (!isset(static::LANGUAGE_PRESETS[$identifier])) {
+            throw new \LogicException(
+                sprintf('Undefined preset identifier "%s"', $identifier),
+                1533893665
+            );
+        }
+        return static::LANGUAGE_PRESETS[$identifier];
+    }
+
+    /**
+     * @param InternalRequest $request
+     * @param AbstractInstruction ...$instructions
+     * @return InternalRequest
+     *
+     * @todo Instruction handling should be part of Testing Framework (multiple instructions per identifier, merge in interface)
+     */
+    protected function applyInstructions(InternalRequest $request, AbstractInstruction ...$instructions): InternalRequest
+    {
+        $modifiedInstructions = [];
+
+        foreach ($instructions as $instruction) {
+            $identifier = $instruction->getIdentifier();
+            if (isset($modifiedInstructions[$identifier]) || $request->getInstruction($identifier) !== null) {
+                $modifiedInstructions[$identifier] = $this->mergeInstruction(
+                    $modifiedInstructions[$identifier] ?? $request->getInstruction($identifier),
+                    $instruction
+                );
+            } else {
+                $modifiedInstructions[$identifier] = $instruction;
+            }
+        }
+
+        return $request->withInstructions($modifiedInstructions);
+    }
+
+    /**
+     * @param AbstractInstruction $current
+     * @param AbstractInstruction $other
+     * @return AbstractInstruction
+     */
+    protected function mergeInstruction(AbstractInstruction $current, AbstractInstruction $other): AbstractInstruction
+    {
+        if (get_class($current) !== get_class($other)) {
+            throw new \LogicException('Cannot merge different instruction types', 1565863174);
+        }
+
+        if ($current instanceof TypoScriptInstruction) {
+            /** @var TypoScriptInstruction $other */
+            $typoScript = array_replace_recursive(
+                $current->getTypoScript() ?? [],
+                $other->getTypoScript() ?? []
+            );
+            $constants = array_replace_recursive(
+                $current->getConstants() ?? [],
+                $other->getConstants() ?? []
+            );
+            if ($typoScript !== []) {
+                $current = $current->withTypoScript($typoScript);
+            }
+            if ($constants !== []) {
+                $current = $current->withConstants($constants);
+            }
+            return $current;
+        }
+
+        if ($current instanceof ArrayValueInstruction) {
+            /** @var ArrayValueInstruction $other */
+            $array = array_merge_recursive($current->getArray(), $other->getArray());
+            return $current->withArray($array);
+        }
+
+        return $current;
+    }
+}

--- a/Tests/Functional/Plugins/AcademicPersonsDetailPluginTest.php
+++ b/Tests/Functional/Plugins/AcademicPersonsDetailPluginTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fgtclb\AcademicPersons\Tests\Functional\Plugins;
+
+use Fgtclb\AcademicPersons\Tests\Functional\Fixtures\Trait\SiteBasedTestTrait;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+final class AcademicPersonsDetailPluginTest extends FunctionalTestCase
+{
+    use SiteBasedTestTrait;
+
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-fluid-styled-content',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'georgringer/numbered-pagination',
+        'fgtclb/academic-persons',
+        'tests/plugin-templates',
+    ];
+
+    protected array $configurationToUseInTestInstance = [
+        'SYS' => [
+            'encryptionKey' => '4408d27a916d51e624b69af3554f516dbab61037a9f7b9fd6f81b4d3bedeccb6',
+            'features' => [
+                'subrequestPageErrors' => true,
+            ],
+        ],
+        'FE' => [
+            'cacheHash' => [
+                'requireCacheHashPresenceParameters' => ['value', 'testing[value]', 'tx_testing_link[value]'],
+                'excludedParameters' => ['L', 'tx_testing_link[excludedValue]'],
+                'enforceValidation' => true,
+            ],
+            'debug' => false,
+        ],
+        'SC_OPTIONS' => [
+            'Core/TypoScript/TemplateService' => [
+                'runThroughTemplatesPostProcessing' => [
+                    'FunctionalTest' => \TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Hook\TypoScriptInstructionModifier::class . '->apply',
+                ],
+            ],
+        ],
+    ];
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
+        'DE' => ['id' => 1, 'title' => 'Deutsch', 'locale' => 'de_DE.UTF8', 'iso' => 'de', 'hrefLang' => 'de-DE', 'direction' => ''],
+        'FR' => ['id' => 2, 'title' => 'French', 'locale' => 'fr_FR.UTF8', 'iso' => 'fr', 'hrefLang' => 'fr-FR', 'direction' => ''],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
+        parent::tearDown();
+    }
+
+    private function setUpFrontendRootPageForTestCase(): void
+    {
+        $this->setUpFrontendRootPage(
+            1,
+            [
+                'constants' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_persons/Configuration/TypoScript/constants.typoscript',
+                    'EXT:test_plugin_templates/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_persons/Tests/Functional/Plugins/Fixtures/TypoScript/Constants/PluginConfiguration.typoscript',
+                ],
+                'setup' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_persons/Configuration/TypoScript/setup.typoscript',
+                    'EXT:test_plugin_templates/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_persons/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript',
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function defaultLanguageDisplayProfile(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsDetailPlugin/defaultLanguageOnly.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest(
+            'https://www.acme.com/home?' . http_build_query([
+                'tx_academicpersons_detail' => [
+                    'controller' => 'Profile',
+                    'action' => 'detail',
+                    'profile' => 1,
+                ],
+                'cHash' => '13c8ec3ab2a317651a40bd164df8a366',
+            ])
+        );
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('#1: [EN] Max Müllermann', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function fullyLocalizedDisplaysLocalizedProfile(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsDetailPlugin/fullyLocalized.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildDefaultLanguageConfiguration('DE', '/de/'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest(
+            'https://www.acme.com/de/home?' . http_build_query([
+                'tx_academicpersons_detail' => [
+                    'controller' => 'Profile',
+                    'action' => 'detail',
+                    'profile' => 1,
+                ],
+                'cHash' => '008c1ca1df782f9191ecb45d4a4123e3',
+            ])
+        );
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('#1: [DE] Max Müllermann', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function localizedPagesAndTtContentWithNotLocalizedProfileDisplayDefaultLanguageWhenLanguageFallback(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsDetailPlugin/localizedPagesAndTtContent_notLocalizedProfile.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'fallback'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest(
+            'https://www.acme.com/de/home?' . http_build_query([
+                'tx_academicpersons_detail' => [
+                    'controller' => 'Profile',
+                    'action' => 'detail',
+                    'profile' => 1,
+                ],
+                'cHash' => '008c1ca1df782f9191ecb45d4a4123e3',
+            ])
+        );
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profiledetailpage</h2>', $content);
+        static::assertStringContainsString('#1: [EN] Max Müllermann', $content);
+    }
+
+    /**
+     * @test
+     * @todo Really ?
+     */
+    public function localizedPagesAndTtContentWithNotLocalizedProfileDisplayDefaultLanguageWhenLanguageStrict(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsDetailPlugin/localizedPagesAndTtContent_notLocalizedProfile.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', [], 'strict'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest(
+            'https://www.acme.com/de/home?' . http_build_query([
+                'tx_academicpersons_detail' => [
+                    'controller' => 'Profile',
+                    'action' => 'detail',
+                    'profile' => 1,
+                ],
+                'cHash' => '008c1ca1df782f9191ecb45d4a4123e3',
+            ])
+        );
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profiledetailpage</h2>', $content);
+        static::assertStringContainsString('#1: [EN] Max Müllermann', $content);
+    }
+}

--- a/Tests/Functional/Plugins/AcademicPersonsListAndDetailPluginTest.php
+++ b/Tests/Functional/Plugins/AcademicPersonsListAndDetailPluginTest.php
@@ -1,0 +1,533 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fgtclb\AcademicPersons\Tests\Functional\Plugins;
+
+use Fgtclb\AcademicPersons\Tests\Functional\Fixtures\Trait\SiteBasedTestTrait;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
+{
+    use SiteBasedTestTrait;
+
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-fluid-styled-content',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'georgringer/numbered-pagination',
+        'fgtclb/academic-persons',
+        'tests/plugin-templates',
+    ];
+
+    protected array $configurationToUseInTestInstance = [
+        'SYS' => [
+            'encryptionKey' => '4408d27a916d51e624b69af3554f516dbab61037a9f7b9fd6f81b4d3bedeccb6',
+            'features' => [
+                'subrequestPageErrors' => true,
+            ],
+        ],
+        'FE' => [
+            'cacheHash' => [
+                'requireCacheHashPresenceParameters' => ['value', 'testing[value]', 'tx_testing_link[value]'],
+                'excludedParameters' => ['L', 'tx_testing_link[excludedValue]'],
+                'enforceValidation' => true,
+            ],
+            'debug' => false,
+        ],
+        'SC_OPTIONS' => [
+            'Core/TypoScript/TemplateService' => [
+                'runThroughTemplatesPostProcessing' => [
+                    'FunctionalTest' => \TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Hook\TypoScriptInstructionModifier::class . '->apply',
+                ],
+            ],
+        ],
+    ];
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
+        'DE' => ['id' => 1, 'title' => 'Deutsch', 'locale' => 'de_DE.UTF8', 'iso' => 'de', 'hrefLang' => 'de-DE', 'direction' => ''],
+        'FR' => ['id' => 2, 'title' => 'French', 'locale' => 'fr_FR.UTF8', 'iso' => 'fr', 'hrefLang' => 'fr-FR', 'direction' => ''],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
+        parent::tearDown();
+    }
+
+    private function setUpFrontendRootPageForTestCase(): void
+    {
+        $this->setUpFrontendRootPage(
+            1,
+            [
+                'constants' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_persons/Configuration/TypoScript/constants.typoscript',
+                    'EXT:test_plugin_templates/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_persons/Tests/Functional/Plugins/Fixtures/TypoScript/Constants/PluginConfiguration.typoscript',
+                ],
+                'setup' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_persons/Configuration/TypoScript/setup.typoscript',
+                    'EXT:test_plugin_templates/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_persons/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript',
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function defaultLanguageListDisplaysAllProfiles(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(1): [EN] Max Müllermann', $content);
+        static::assertStringContainsString('#1(2): [EN] Horst Huber', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function defaultLanguageDisplayProfile(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest(
+            'https://www.acme.com/home?' . http_build_query([
+                'tx_academicpersons_listanddetail' => [
+                    'controller' => 'Profile',
+                    'action' => 'detail',
+                    'profile' => 1,
+                ],
+                'cHash' => 'fee6f7f7bcd9035d23f9d6062fc6b7c5',
+            ])
+        );
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profiledetailpage</h2>', $content);
+        static::assertStringContainsString('#1: [EN] Max Müllermann', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function defaultLanguageListDisplaySingleSelectedProfile(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly_oneProfileSelected.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(2): Horst Huber', $content);
+        static::assertStringNotContainsString('Max Müllermann', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function defaultLanguageListDisplaysSelectedProfilesInSelectedOrder(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly_selectedProfiles.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(2): Horst Huber', $content);
+        static::assertStringContainsString('#1(1): Max Müllermann', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function fullyLocalizedDisplaysLocalizedProfile(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildDefaultLanguageConfiguration('DE', '/de/'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest(
+            'https://www.acme.com/de/home?' . http_build_query([
+                'tx_academicpersons_listanddetail' => [
+                    'controller' => 'Profile',
+                    'action' => 'detail',
+                    'profile' => 1,
+                ],
+                'cHash' => 'f497a1175d10a3c77454c5958cc1fc5c',
+            ])
+        );
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profiledetailpage</h2>', $content);
+        static::assertStringContainsString('#1: [DE] Max Müllermann', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function localizedPagesAndTtContentWithNotLocalizedProfileDisplayDefaultLanguageWhenLanguageFallback(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/localizedPagesAndTtContent_notLocalizedProfile.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'fallback'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest(
+            'https://www.acme.com/de/home?' . http_build_query([
+                'tx_academicpersons_listanddetail' => [
+                    'controller' => 'Profile',
+                    'action' => 'detail',
+                    'profile' => 1,
+                ],
+                'cHash' => 'f497a1175d10a3c77454c5958cc1fc5c',
+            ])
+        );
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profiledetailpage</h2>', $content);
+        static::assertStringContainsString('#1: [EN] Max Müllermann', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function fullyLocalizedListDisplaysDefaultLanguageProfilesForRequestedDefaultLanguage(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(1): [EN] Max Müllermann', $content);
+        static::assertStringContainsString('#1(3): [EN] Horst Huber', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function fullyLocalizedListDisplaysLocalizedProfilesForRequestedLanguage(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/de/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
+        static::assertStringContainsString('#1(3): [DE] Horst Huber', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function fullyLocalizedPagesAndTtContentListDisplaysOnlyLocalizedProfilesForRequestedLanguageWithNotAllProfilesLocalizedInStrictMode(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', [], 'strict'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/de/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
+        static::assertStringNotContainsString('Horst Huber', $content);
+    }
+
+    /**
+     * @test
+     *
+     * Cover `fallbackForNonTranslated` option introduced with https://github.com/fgtclb/academic-persons/pull/30 to
+     * have an option to get default language profiles for non-translated profiled when siteLanguage is in strict mode.
+     */
+    public function fullyLocalizedPagesAndTtContentListDisplaysOnlyLocalizedProfilesForRequestedLanguageWithNotAllProfilesLocalizedInStrictModeWithFallbackForNonTranslatedSet(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', [], 'strict'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/de/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
+        static::assertStringContainsString('#1(3): [EN] Horst Huber', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function fullyLocalizedPagesAndTtContentListDisplaysLocalizedProfileAndDefaultLanguageProfileForRequestedLanguageWithNotAllProfilesLocalizedInFallbackMode(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'fallback'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/de/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
+        static::assertStringContainsString('#1(3): [EN] Horst Huber', $content);
+    }
+
+    /**
+     * @test
+     * @todo This is expected to work. Remove skipping test when fixing it.
+     */
+    public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrder(): void
+    {
+        static::markTestSkipped('Expected to work, but does not. Skipped until fixed.');
+        //$this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles.csv');
+        //$this->setUpFrontendRootPageForTestCase();
+        //$this->writeSiteConfiguration(
+        //    'acme',
+        //    $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+        //    [
+        //        $this->buildDefaultLanguageConfiguration('EN', '/'),
+        //        $this->buildLanguageConfiguration('DE', '/de/'),
+        //    ]
+        //);
+        //
+        //$requestContext = new InternalRequestContext();
+        //$request = new InternalRequest('https://www.acme.com/de/home');
+        //$response = $this->executeFrontendSubRequest($request, $requestContext);
+        //self::assertSame(200, $response->getStatusCode());
+        //
+        //$content = (string)$response->getBody();
+        //static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        //static::assertStringContainsString('#0(3): [DE] Horst Huber', $content);
+        //static::assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
+        //static::assertStringNotContainsString('[EN] Horst Huber', $content);
+        //static::assertStringNotContainsString('[EN] Max Müllermann', $content);
+    }
+
+
+    /**
+     * @test
+     * @todo This is expected to work. Remove skipping test when fixing it.
+     */
+    public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeStrictWhenNotAllProfilesAreLocalized(): void
+    {
+        static::markTestSkipped('Expected to work, but does not. Skipped until fixed.');
+        //$this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv');
+        //$this->setUpFrontendRootPageForTestCase();
+        //$this->writeSiteConfiguration(
+        //    'acme',
+        //    $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+        //    [
+        //        $this->buildDefaultLanguageConfiguration('EN', '/'),
+        //        $this->buildLanguageConfiguration('DE', '/de/', [], 'strict'),
+        //    ]
+        //);
+        //
+        //$requestContext = new InternalRequestContext();
+        //$request = new InternalRequest('https://www.acme.com/de/home');
+        //$response = $this->executeFrontendSubRequest($request, $requestContext);
+        //self::assertSame(200, $response->getStatusCode());
+        //
+        //$content = (string)$response->getBody();
+        //static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        //static::assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
+        //static::assertStringNotContainsString('[EN] Horst Huber', $content);
+        //static::assertStringNotContainsString('[DE] Horst Huber', $content);
+        //static::assertStringNotContainsString('[EN] Max Müllermann', $content);
+    }
+
+    /**
+     * @test
+     * @todo This is expected to work. Remove skipping test when fixing it.
+     */
+    public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeStrictWhenNotAllProfilesAreLocalizedButPluginFallbackSet(): void
+    {
+        static::markTestSkipped('Expected to work, but does not. Skipped until fixed.');
+        //$this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv');
+        //$this->setUpFrontendRootPageForTestCase();
+        //$this->writeSiteConfiguration(
+        //    'acme',
+        //    $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+        //    [
+        //        $this->buildDefaultLanguageConfiguration('EN', '/'),
+        //        $this->buildLanguageConfiguration('DE', '/de/'),
+        //    ]
+        //);
+        //
+        //$requestContext = new InternalRequestContext();
+        //$request = new InternalRequest('https://www.acme.com/de/home');
+        //$response = $this->executeFrontendSubRequest($request, $requestContext);
+        //self::assertSame(200, $response->getStatusCode());
+        //
+        //$content = (string)$response->getBody();
+        //static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        //static::assertStringContainsString('#0(3): [EN] Horst Huber', $content);
+        //static::assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
+        //static::assertStringNotContainsString('[DE] Horst Huber', $content);
+        //static::assertStringNotContainsString('[EN] Max Müllermann', $content);
+    }
+
+    /**
+     * @test
+     * @todo This is expected to work. Remove skipping test when fixing it.
+     */
+    public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeFallbackWhenNotAllProfilesAreLocalized(): void
+    {
+        static::markTestSkipped('Expected to work, but does not. Skipped until fixed.');
+        //$this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv');
+        //$this->setUpFrontendRootPageForTestCase();
+        //$this->writeSiteConfiguration(
+        //    'acme',
+        //    $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+        //    [
+        //        $this->buildDefaultLanguageConfiguration('EN', '/'),
+        //        $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'fallback'),
+        //    ]
+        //);
+        //
+        //$requestContext = new InternalRequestContext();
+        //$request = new InternalRequest('https://www.acme.com/de/home');
+        //$response = $this->executeFrontendSubRequest($request, $requestContext);
+        //self::assertSame(200, $response->getStatusCode());
+        //
+        //$content = (string)$response->getBody();
+        //static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        //static::assertStringContainsString('#0(3): [EN] Horst Huber', $content);
+        //static::assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
+        //static::assertStringNotContainsString('[DE] Horst Huber', $content);
+        //static::assertStringNotContainsString('[EN] Max Müllermann', $content);
+    }
+}

--- a/Tests/Functional/Plugins/AcademicPersonsListPluginTest.php
+++ b/Tests/Functional/Plugins/AcademicPersonsListPluginTest.php
@@ -1,0 +1,428 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fgtclb\AcademicPersons\Tests\Functional\Plugins;
+
+use Fgtclb\AcademicPersons\Tests\Functional\Fixtures\Trait\SiteBasedTestTrait;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+final class AcademicPersonsListPluginTest extends FunctionalTestCase
+{
+    use SiteBasedTestTrait;
+
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-fluid-styled-content',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'georgringer/numbered-pagination',
+        'fgtclb/academic-persons',
+        'tests/plugin-templates',
+    ];
+
+    protected array $configurationToUseInTestInstance = [
+        'SYS' => [
+            'encryptionKey' => '4408d27a916d51e624b69af3554f516dbab61037a9f7b9fd6f81b4d3bedeccb6',
+            'features' => [
+                'subrequestPageErrors' => true,
+            ],
+        ],
+        'FE' => [
+            'cacheHash' => [
+                'requireCacheHashPresenceParameters' => ['value', 'testing[value]', 'tx_testing_link[value]'],
+                'excludedParameters' => ['L', 'tx_testing_link[excludedValue]'],
+                'enforceValidation' => true,
+            ],
+            'debug' => false,
+        ],
+        'SC_OPTIONS' => [
+            'Core/TypoScript/TemplateService' => [
+                'runThroughTemplatesPostProcessing' => [
+                    'FunctionalTest' => \TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Hook\TypoScriptInstructionModifier::class . '->apply',
+                ],
+            ],
+        ],
+    ];
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
+        'DE' => ['id' => 1, 'title' => 'Deutsch', 'locale' => 'de_DE.UTF8', 'iso' => 'de', 'hrefLang' => 'de-DE', 'direction' => ''],
+        'FR' => ['id' => 2, 'title' => 'French', 'locale' => 'fr_FR.UTF8', 'iso' => 'fr', 'hrefLang' => 'fr-FR', 'direction' => ''],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
+        parent::tearDown();
+    }
+
+    private function setUpFrontendRootPageForTestCase(): void
+    {
+        $this->setUpFrontendRootPage(
+            1,
+            [
+                'constants' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_persons/Configuration/TypoScript/constants.typoscript',
+                    'EXT:test_plugin_templates/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_persons/Tests/Functional/Plugins/Fixtures/TypoScript/Constants/PluginConfiguration.typoscript',
+                ],
+                'setup' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_persons/Configuration/TypoScript/setup.typoscript',
+                    'EXT:test_plugin_templates/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_persons/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript',
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function defaultLanguageListDisplaysAllProfiles(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(1): Max Müllermann', $content);
+        static::assertStringContainsString('#1(2): Horst Huber', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function defaultLanguageListDisplaySingleSelectedProfile(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly_oneProfileSelected.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(2): Horst Huber', $content);
+        static::assertStringNotContainsString('Max Müllermann', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function defaultLanguageListDisplaysSelectedProfilesInSelectedOrder(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly_selectedProfiles.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(2): Horst Huber', $content);
+        static::assertStringContainsString('#1(1): Max Müllermann', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function fullyLocalizedListDisplaysDefaultLanguageProfilesForRequestedDefaultLanguage(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(1): [EN] Max Müllermann', $content);
+        static::assertStringContainsString('#1(3): [EN] Horst Huber', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function fullyLocalizedListDisplaysLocalizedProfilesForRequestedLanguage(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/de/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
+        static::assertStringContainsString('#1(3): [DE] Horst Huber', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function fullyLocalizedPagesAndTtContentListDisplaysOnlyLocalizedProfilesForRequestedLanguageWithNotAllProfilesLocalizedInStrictMode(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', [], 'strict'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/de/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
+        static::assertStringNotContainsString('Horst Huber', $content);
+    }
+
+    /**
+     * @test
+     *
+     * Cover `fallbackForNonTranslated` option introduced with https://github.com/fgtclb/academic-persons/pull/30 to
+     * have an option to get default language profiles for non-translated profiled when siteLanguage is in strict mode.
+     */
+    public function fullyLocalizedPagesAndTtContentListDisplaysOnlyLocalizedProfilesForRequestedLanguageWithNotAllProfilesLocalizedInStrictModeWithFallbackForNonTranslatedSet(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', [], 'strict'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/de/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
+        static::assertStringContainsString('#1(3): [EN] Horst Huber', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function fullyLocalizedPagesAndTtContentListDisplaysLocalizedProfileAndDefaultLanguageProfileForRequestedLanguageWithNotAllProfilesLocalizedInFallbackMode(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'fallback'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/de/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
+        static::assertStringContainsString('#1(3): [EN] Horst Huber', $content);
+    }
+
+    /**
+     * @test
+     * @todo This is expected to work. Remove skipping test when fixing it.
+     */
+    public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrder(): void
+    {
+        static::markTestSkipped('Expected to work, but does not. Skipped until fixed.');
+        //$this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles.csv');
+        //$this->setUpFrontendRootPageForTestCase();
+        //$this->writeSiteConfiguration(
+        //    'acme',
+        //    $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+        //    [
+        //        $this->buildDefaultLanguageConfiguration('EN', '/'),
+        //        $this->buildLanguageConfiguration('DE', '/de/'),
+        //    ]
+        //);
+        //
+        //$requestContext = new InternalRequestContext();
+        //$request = new InternalRequest('https://www.acme.com/de/home');
+        //$response = $this->executeFrontendSubRequest($request, $requestContext);
+        //self::assertSame(200, $response->getStatusCode());
+        //
+        //$content = (string)$response->getBody();
+        //static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        //static::assertStringContainsString('#0(3): [DE] Horst Huber', $content);
+        //static::assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
+        //static::assertStringNotContainsString('[EN] Horst Huber', $content);
+        //static::assertStringNotContainsString('[EN] Max Müllermann', $content);
+    }
+
+    /**
+     * @test
+     * @todo This is expected to work. Remove skipping test when fixing it.
+     */
+    public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeStrictWhenNotAllProfilesAreLocalized(): void
+    {
+        static::markTestSkipped('Expected to work, but does not. Skipped until fixed.');
+        //$this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv');
+        //$this->setUpFrontendRootPageForTestCase();
+        //$this->writeSiteConfiguration(
+        //    'acme',
+        //    $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+        //    [
+        //        $this->buildDefaultLanguageConfiguration('EN', '/'),
+        //        $this->buildLanguageConfiguration('DE', '/de/', [], 'strict'),
+        //    ]
+        //);
+        //
+        //$requestContext = new InternalRequestContext();
+        //$request = new InternalRequest('https://www.acme.com/de/home');
+        //$response = $this->executeFrontendSubRequest($request, $requestContext);
+        //self::assertSame(200, $response->getStatusCode());
+        //
+        //$content = (string)$response->getBody();
+        //static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        //static::assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
+        //static::assertStringNotContainsString('[EN] Horst Huber', $content);
+        //static::assertStringNotContainsString('[DE] Horst Huber', $content);
+        //static::assertStringNotContainsString('[EN] Max Müllermann', $content);
+    }
+
+    /**
+     * @test
+     * @todo This is expected to work. Remove skipping test when fixing it.
+     */
+    public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeStrictWhenNotAllProfilesAreLocalizedButPluginFallbackSet(): void
+    {
+        static::markTestSkipped('Expected to work, but does not. Skipped until fixed.');
+        //$this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv');
+        //$this->setUpFrontendRootPageForTestCase();
+        //$this->writeSiteConfiguration(
+        //    'acme',
+        //    $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+        //    [
+        //        $this->buildDefaultLanguageConfiguration('EN', '/'),
+        //        $this->buildLanguageConfiguration('DE', '/de/'),
+        //    ]
+        //);
+        //
+        //$requestContext = new InternalRequestContext();
+        //$request = new InternalRequest('https://www.acme.com/de/home');
+        //$response = $this->executeFrontendSubRequest($request, $requestContext);
+        //self::assertSame(200, $response->getStatusCode());
+        //
+        //$content = (string)$response->getBody();
+        //static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        //static::assertStringContainsString('#0(3): [EN] Horst Huber', $content);
+        //static::assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
+        //static::assertStringNotContainsString('[DE] Horst Huber', $content);
+        //static::assertStringNotContainsString('[EN] Max Müllermann', $content);
+    }
+
+    /**
+     * @test
+     * @todo This is expected to work. Remove skipping test when fixing it.
+     */
+    public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeFallbackWhenNotAllProfilesAreLocalized(): void
+    {
+        static::markTestSkipped('Expected to work, but does not. Skipped until fixed.');
+        //$this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv');
+        //$this->setUpFrontendRootPageForTestCase();
+        //$this->writeSiteConfiguration(
+        //    'acme',
+        //    $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+        //    [
+        //        $this->buildDefaultLanguageConfiguration('EN', '/'),
+        //        $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'fallback'),
+        //    ]
+        //);
+        //
+        //$requestContext = new InternalRequestContext();
+        //$request = new InternalRequest('https://www.acme.com/de/home');
+        //$response = $this->executeFrontendSubRequest($request, $requestContext);
+        //self::assertSame(200, $response->getStatusCode());
+        //
+        //$content = (string)$response->getBody();
+        //static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        //static::assertStringContainsString('#0(3): [EN] Horst Huber', $content);
+        //static::assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
+        //static::assertStringNotContainsString('[DE] Horst Huber', $content);
+        //static::assertStringNotContainsString('[EN] Max Müllermann', $content);
+    }
+}

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsDetailPlugin/defaultLanguageOnly.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsDetailPlugin/defaultLanguageOnly.csv
@@ -1,0 +1,12 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,2,0,0,0,0,"list","academicpersons_detail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"[EN] Horst","Huber","horst-huber"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsDetailPlugin/fullyLocalized.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsDetailPlugin/fullyLocalized.csv
@@ -1,0 +1,16 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root (EN)"
+,2,0,1,0,0,1,1,0,"/","Site Root (DE)"
+,3,1,1,0,0,0,0,0,"/home","Home (EN)"
+,4,1,1,0,0,1,3,0,"/home","Home (EN)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,1,100,0,"/sysfolder-records","Recordcollection"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,3,0,0,0,0,"list","academicpersons_detail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"list","academicpersons_detail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"
+,2,100,0,0,1,1,"[DE] Max","Müllermann","max-muellermann"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsDetailPlugin/localizedPagesAndTtContent_notLocalizedProfile.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsDetailPlugin/localizedPagesAndTtContent_notLocalizedProfile.csv
@@ -1,0 +1,15 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root (EN)"
+,2,0,1,0,0,1,1,0,"/","Site Root (DE)"
+,3,1,1,0,0,0,0,0,"/home","Home (EN)"
+,4,1,1,0,0,1,3,0,"/home","Home (EN)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,1,100,0,"/sysfolder-records","Recordcollection"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,3,0,0,0,0,"list","academicpersons_detail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"list","academicpersons_detail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly.csv
@@ -1,0 +1,12 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,2,0,0,0,0,"list","academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"[EN] Horst","Huber","horst-huber"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly_oneProfileSelected.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly_oneProfileSelected.csv
@@ -1,0 +1,12 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,2,0,0,0,0,"list","academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">2</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"Horst","Huber","horst-huber"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly_selectedProfiles.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly_selectedProfiles.csv
@@ -1,0 +1,12 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,2,0,0,0,0,"list","academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">2,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"Horst","Huber","horst-huber"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized.csv
@@ -1,0 +1,18 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root (EN)"
+,2,0,1,0,0,1,1,0,"/","Site Root (DE)"
+,3,1,1,0,0,0,0,0,"/home","Home (EN)"
+,4,1,1,0,0,1,3,0,"/home","Home (DE)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,3,0,0,0,0,"list","academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"list","academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"
+,2,100,0,0,1,1,"[DE] Max","Müllermann","max-muellermann"
+,3,100,0,0,0,0,"[EN] Horst","Huber","horst-huber"
+,4,100,0,0,1,3,"[DE] Horst","Huber","horst-huber"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv
@@ -1,0 +1,17 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root (EN)"
+,2,0,1,0,0,1,1,0,"/","Site Root (DE)"
+,3,1,1,0,0,0,0,0,"/home","Home (EN)"
+,4,1,1,0,0,1,3,0,"/home","Home (DE)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,3,0,0,0,0,"list","academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"list","academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"
+,2,100,0,0,1,1,"[DE] Max","Müllermann","max-muellermann"
+,3,100,0,0,0,0,"[EN] Horst","Huber","horst-huber"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv
@@ -1,0 +1,17 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root (EN)"
+,2,0,1,0,0,1,1,0,"/","Site Root (DE)"
+,3,1,1,0,0,0,0,0,"/home","Home (EN)"
+,4,1,1,0,0,1,3,0,"/home","Home (DE)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,3,0,0,0,0,"list","academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"list","academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"
+,2,100,0,0,1,1,"[DE] Max","Müllermann","max-muellermann"
+,3,100,0,0,0,0,"[EN] Horst","Huber","horst-huber"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles.csv
@@ -1,0 +1,18 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root (EN)"
+,2,0,1,0,0,1,1,0,"/","Site Root (DE)"
+,3,1,1,0,0,0,0,0,"/home","Home (EN)"
+,4,1,1,0,0,1,3,0,"/home","Home (DE)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,3,0,0,0,0,"list","academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"list","academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"
+,2,100,0,0,1,1,"[DE] Max","Müllermann","max-muellermann"
+,3,100,0,0,0,0,"[EN] Horst","Huber","horst-huber"
+,4,100,0,0,1,3,"[DE] Horst","Huber","horst-huber"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv
@@ -1,0 +1,17 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root (EN)"
+,2,0,1,0,0,1,1,0,"/","Site Root (DE)"
+,3,1,1,0,0,0,0,0,"/home","Home (EN)"
+,4,1,1,0,0,1,3,0,"/home","Home (DE)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,3,0,0,0,0,"list","academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"list","academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"
+,2,100,0,0,1,1,"[DE] Max","Müllermann","max-muellermann"
+,3,100,0,0,0,0,"[EN] Horst","Huber","horst-huber"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv
@@ -1,0 +1,17 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root (EN)"
+,2,0,1,0,0,1,1,0,"/","Site Root (DE)"
+,3,1,1,0,0,0,0,0,"/home","Home (EN)"
+,4,1,1,0,0,1,3,0,"/home","Home (DE)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,3,0,0,0,0,"list","academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"list","academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"
+,2,100,0,0,1,1,"[DE] Max","Müllermann","max-muellermann"
+,3,100,0,0,0,0,"[EN] Horst","Huber","horst-huber"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/localizedPagesAndTtContent_notLocalizedProfile.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/localizedPagesAndTtContent_notLocalizedProfile.csv
@@ -1,0 +1,15 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root (EN)"
+,2,0,1,0,0,1,1,0,"/","Site Root (DE)"
+,3,1,1,0,0,0,0,0,"/home","Home (EN)"
+,4,1,1,0,0,1,3,0,"/home","Home (EN)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,1,100,0,"/sysfolder-records","Recordcollection"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,3,0,0,0,0,"list","academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"list","academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly.csv
@@ -1,0 +1,12 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,2,0,0,0,0,"list","academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"Horst","Huber","horst-huber"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly_oneProfileSelected.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly_oneProfileSelected.csv
@@ -1,0 +1,12 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,2,0,0,0,0,"list","academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">2</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"Horst","Huber","horst-huber"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly_selectedProfiles.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly_selectedProfiles.csv
@@ -1,0 +1,12 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,2,0,0,0,0,"list","academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">2,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"Horst","Huber","horst-huber"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalized.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalized.csv
@@ -1,0 +1,18 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root (EN)"
+,2,0,1,0,0,1,1,0,"/","Site Root (DE)"
+,3,1,1,0,0,0,0,0,"/home","Home (EN)"
+,4,1,1,0,0,1,3,0,"/home","Home (DE)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,3,0,0,0,0,"list","academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"list","academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"
+,2,100,0,0,1,1,"[DE] Max","Müllermann","max-muellermann"
+,3,100,0,0,0,0,"[EN] Horst","Huber","horst-huber"
+,4,100,0,0,1,3,"[DE] Horst","Huber","horst-huber"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv
@@ -1,0 +1,17 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root (EN)"
+,2,0,1,0,0,1,1,0,"/","Site Root (DE)"
+,3,1,1,0,0,0,0,0,"/home","Home (EN)"
+,4,1,1,0,0,1,3,0,"/home","Home (DE)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,3,0,0,0,0,"list","academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"list","academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"
+,2,100,0,0,1,1,"[DE] Max","Müllermann","max-muellermann"
+,3,100,0,0,0,0,"[EN] Horst","Huber","horst-huber"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv
@@ -1,0 +1,17 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root (EN)"
+,2,0,1,0,0,1,1,0,"/","Site Root (DE)"
+,3,1,1,0,0,0,0,0,"/home","Home (EN)"
+,4,1,1,0,0,1,3,0,"/home","Home (DE)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,3,0,0,0,0,"list","academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"list","academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"
+,2,100,0,0,1,1,"[DE] Max","Müllermann","max-muellermann"
+,3,100,0,0,0,0,"[EN] Horst","Huber","horst-huber"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles.csv
@@ -1,0 +1,18 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root (EN)"
+,2,0,1,0,0,1,1,0,"/","Site Root (DE)"
+,3,1,1,0,0,0,0,0,"/home","Home (EN)"
+,4,1,1,0,0,1,3,0,"/home","Home (DE)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,3,0,0,0,0,"list","academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"list","academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"
+,2,100,0,0,1,1,"[DE] Max","Müllermann","max-muellermann"
+,3,100,0,0,0,0,"[EN] Horst","Huber","horst-huber"
+,4,100,0,0,1,3,"[DE] Horst","Huber","horst-huber"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv
@@ -1,0 +1,17 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root (EN)"
+,2,0,1,0,0,1,1,0,"/","Site Root (DE)"
+,3,1,1,0,0,0,0,0,"/home","Home (EN)"
+,4,1,1,0,0,1,3,0,"/home","Home (DE)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,3,0,0,0,0,"list","academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"list","academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"
+,2,100,0,0,1,1,"[DE] Max","Müllermann","max-muellermann"
+,3,100,0,0,0,0,"[EN] Horst","Huber","horst-huber"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv
@@ -1,0 +1,17 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root (EN)"
+,2,0,1,0,0,1,1,0,"/","Site Root (DE)"
+,3,1,1,0,0,0,0,0,"/home","Home (EN)"
+,4,1,1,0,0,1,3,0,"/home","Home (DE)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,3,0,0,0,0,"list","academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"list","academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"
+,2,100,0,0,1,1,"[DE] Max","Müllermann","max-muellermann"
+,3,100,0,0,0,0,"[EN] Horst","Huber","horst-huber"

--- a/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript
+++ b/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript
@@ -1,0 +1,4 @@
+page = PAGE
+page {
+  10 < styles.content.get
+}

--- a/composer.json
+++ b/composer.json
@@ -25,16 +25,17 @@
         "georgringer/numbered-pagination": "^1.0"
     },
     "require-dev": {
-        "typo3/minimal": "v11.5.0",
-        "typo3/cms-composer-installers": "v4.0.0-RC1",
-        "kaystrobach/migrations": "0.11.0",
-        "helhum/typo3-console": "^7.1 || ^8.0",
-        "saschaegerer/phpstan-typo3": "^1.8",
-        "friendsofphp/php-cs-fixer": "^3.14",
         "andreaswolf/typo3-uuid": "^0.3.0",
-        "typo3/testing-framework": "^7.0",
         "bk2k/bootstrap-package": "^14.0",
-        "cweagans/composer-patches": "^1.7"
+        "cweagans/composer-patches": "^1.7",
+        "friendsofphp/php-cs-fixer": "^3.14",
+        "helhum/typo3-console": "^7.1 || ^8.0",
+        "kaystrobach/migrations": "0.11.0",
+        "saschaegerer/phpstan-typo3": "^1.8",
+        "typo3/cms-composer-installers": "v4.0.0-RC1",
+        "typo3/cms-fluid-styled-content": "^11.5",
+        "typo3/minimal": "v11.5.0",
+        "typo3/testing-framework": "^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- **[TASK] Adjust phpstan configuration**
  Instead of having ext_emconf.php as ignore pattern,
  exclude the root and functional fixture extension
  files directly.
  

- **[TASK] Add SiteBasedTestTrait (v11) and frontend fixture extension**
  This change adds the TYPO3 SiteBasedTestTrait along with
  required side files and a test fixture extension for test
  specific overrides to the system.
  
  Fixture extension is loaded into the typo3/testing-framework
  composer package manger to allow selecting fixture extension
  based on the composer package name.
  

- **[TASK] Add functional tests for all three frontend plugins**
  This change adds a bunch of functional tests for all three
  frontend extbase plugins (list_type) to cover the shared
  `ProfileController` in all usages.
  
  Listing pre-selected profiles (flexform setting) on fully
  localized page and tt_content does not display any profile
  despite the fact that localized profiles in that language
  exists. Corresponding test skipped but added as preparation
  to fix the issue.
  
  Used command(s):
  
  ```shell
  composer require --dev \
    "typo3/cms-fluid-styled-content":"^11.5"
  ```
  
  [1] https://github.com/fgtclb/academic-persons/pull/30
  