### PR TITLE
[TASK] Add storage pages and plugin fallback option to demand object

### DIFF
--- a/Classes/Controller/ProfileController.php
+++ b/Classes/Controller/ProfileController.php
@@ -143,23 +143,70 @@ final class ProfileController extends ActionController
         $context = GeneralUtility::makeInstance(Context::class);
         $querySettings = new Typo3QuerySettings($context, $this->configurationManager);
         $contentObjectData = $this->configurationManager->getContentObject()?->data;
-        if (is_array($contentObjectData)
+        $setDefaultQuerySettings = false;
+        $hasStoragePids = (
+            is_array($contentObjectData)
             && !empty($contentObjectData['pages'])
-        ) {
-            $querySettings->setStoragePageIds(
-                GeneralUtility::intExplode(',', $contentObjectData['pages'])
-            );
+            && is_string($contentObjectData['data'])
+        );
+        if (method_exists($demand, 'setStoragePages')) {
+            if ($hasStoragePids) {
+                // @todo See ProfileRepository::applyDemandSettings().
+                $demand->setStoragePages($contentObjectData['data']);
+            }
         } else {
-            $querySettings->setRespectStoragePage(false);
+            trigger_error(
+                sprintf(
+                    'Class "%s" does not implement methods "%s" and "%s", which is deprecated, and will be added '
+                    . 'breaking with 1.x to interface "%s". Interface already includes commented method signature.',
+                    $demand::class,
+                    'setStoragePages',
+                    'getStoragePages',
+                    DemandInterface::class,
+                ),
+                E_USER_DEPRECATED
+            );
+            $setDefaultQuerySettings = true;
+            if ($hasStoragePids) {
+                $querySettings->setStoragePageIds(
+                    GeneralUtility::intExplode(',', $contentObjectData['pages'])
+                );
+            } else {
+                $querySettings->setRespectStoragePage(false);
+            }
+        }
+        /**
+         * Introduced with https://github.com/fgtclb/academic-persons/pull/30 to have the option to display profiles in
+         * fallback mode even when site language (non-default) is configured to be in strict mode.
+         *
+         * {@see AcademicPersonsListAndDetailPluginTest::fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrder()}
+         * {@see AcademicPersonsListPluginTest::fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrder()}
+         */
+        $fallbackForNonTranslated = (int)($this->settings['fallbackForNonTranslated'] ?? 0);
+        if ($fallbackForNonTranslated === 1) {
+            if (method_exists($demand, 'setFallbackForNonTranslated')) {
+                // @todo See ProfileRepository::applyDemandSettings().
+                $demand->setFallbackForNonTranslated($fallbackForNonTranslated);
+            } else {
+                trigger_error(
+                    sprintf(
+                        'Class "%s" does not implement methods "%s" and "%s", which is deprecated, and will be added '
+                        . 'breaking with 1.x to interface "%s". Interface already includes commented method signature.',
+                        $demand::class,
+                        'setFallbackForNonTranslated',
+                        'getFallbackForNonTranslated',
+                        DemandInterface::class,
+                    ),
+                    E_USER_DEPRECATED
+                );
+                $setDefaultQuerySettings = true;
+                $querySettings->setLanguageOverlayMode(true);
+            }
         }
 
-        // Introduced with https://github.com/fgtclb/academic-persons/pull/30 to have the option to display profiles in
-        // fallback mode even when site language (non-default) is configured to be in strict mode.
-        // See: AcademicPersonsListPluginTest::fullyLocalizedPagesAndTtContentListDisplaysOnlyLocalizedProfilesForRequestedLanguageWithNotAllProfilesLocalizedInStrictModeWithFallbackForNonTranslatedSet()
-        if ((int)($this->settings['fallbackForNonTranslated'] ?? 0) === 1) {
-            $querySettings->setLanguageOverlayMode(true);
+        // @todo Remove this when direct set code is removed with next major version, and Demand is fully source-of-truth.
+        if ($setDefaultQuerySettings) {
+            $this->profileRepository->setDefaultQuerySettings($querySettings);
         }
-
-        $this->profileRepository->setDefaultQuerySettings($querySettings);
     }
 }

--- a/Classes/Domain/Model/Dto/DemandInterface.php
+++ b/Classes/Domain/Model/Dto/DemandInterface.php
@@ -13,27 +13,93 @@ namespace Fgtclb\AcademicPersons\Domain\Model\Dto;
 
 interface DemandInterface
 {
+    /**
+     * Does not have any effect when {@see self::getProfileList()} is not empty.
+     */
     public function getGroupBy(): string;
 
+    /**
+     * Does not have any effect when {@see self::getProfileList()} is not empty.
+     */
     public function setGroupBy(string $groupBy): self;
 
+    /**
+     * Does not have any effect when {@see self::getProfileList()} is not empty.
+     */
     public function getSortBy(): string;
 
+    /**
+     * Does not have any effect when {@see self::getProfileList()} is not empty.
+     */
     public function setSortBy(string $sortBy): self;
 
+    /**
+     * Does not have any effect when {@see self::getProfileList()} is not empty.
+     */
     public function getSortByDirection(): string;
 
+    /**
+     * Does not have any effect when {@see self::getProfileList()} is not empty.
+     */
     public function setSortByDirection(string $sortByDirection): self;
 
+    /**
+     * Does not have any effect when {@see self::getProfileList()} is not empty.
+     */
     public function setCurrentPage(int $currentPage): self;
 
+    /**
+     * Does not have any effect when {@see self::getProfileList()} is not empty.
+     */
     public function getCurrentPage(): int;
 
+    /**
+     * Does not have any effect when {@see self::getProfileList()} is not empty.
+     */
     public function setAlphabetFilter(string $alphabetFilter): self;
 
+    /**
+     * Does not have any effect when {@see self::getProfileList()} is not empty.
+     */
     public function getAlphabetFilter(): string;
 
     public function setProfileList(string $profileList): self;
 
     public function getProfileList(): string;
+
+    /**
+     * Not usable for hydration or direct extbase request argument mapping,
+     * only to transport direct storage page selection within the DTO to the
+     * {@see ProfileRepository::findByDemand()} method.
+     *
+     * @todo Add to interface with next major version as breaking change.
+     */
+    //public function getStoragePages(): string;
+
+    /**
+     * Not usable for hydration or direct extbase request argument mapping,
+     * only to transport direct storage page selection within the DTO to the
+     * {@see ProfileRepository::findByDemand()} method.
+     *
+     * @todo Add to interface with next major version as breaking change.
+     */
+    //public function setStoragePages(string $storagePages): ProfileDemand;
+
+    /**
+     * Not usable for hydration or direct extbase request argument mapping,
+     * only to transport direct storage page selection within the DTO to the
+     * {@see ProfileRepository::findByDemand()} method.
+     *
+     * @todo Add to interface with next major version as breaking change.
+     */
+    // public function getFallbackForNonTranslated(): int;
+
+    /**
+     * Not usable for hydration or direct extbase request argument mapping,
+     * only to transport direct storage page selection within the DTO to the
+     * {@see ProfileRepository::findByDemand()} method.
+     *
+     * @todo Add to interface with next major version as breaking change.
+     */
+    //public function setFallbackForNonTranslated(int $fallbackForNonTranslated): ProfileDemand;
 }

--- a/Classes/Domain/Model/Dto/ProfileDemand.php
+++ b/Classes/Domain/Model/Dto/ProfileDemand.php
@@ -11,83 +11,168 @@ declare(strict_types=1);
 
 namespace Fgtclb\AcademicPersons\Domain\Model\Dto;
 
+use Fgtclb\AcademicPersons\Domain\Repository\ProfileRepository;
+
 class ProfileDemand implements DemandInterface
 {
     protected string $groupBy = '';
-
     protected string $sortBy = 'lastName';
-
     protected string $sortByDirection = 'asc';
-
     protected int $currentPage = 1;
-
     protected string $alphabetFilter = '';
-
     protected string $profileList = '';
+    private string $storagePages = '';
+    private int $fallbackForNonTranslated = 0;
 
+    /**
+     * Does not have any effect when {@see self::getProfileList()} is not empty.
+     */
     public function getGroupBy(): string
     {
         return $this->groupBy;
     }
 
+    /**
+     * Does not have any effect when {@see self::getProfileList()} is not empty.
+     */
     public function setGroupBy(string $groupBy): self
     {
         $this->groupBy = $groupBy;
         return $this;
     }
 
+    /**
+     * Does not have any effect when {@see self::getProfileList()} is not empty.
+     */
     public function getSortBy(): string
     {
         return $this->sortBy;
     }
 
+    /**
+     * Does not have any effect when {@see self::getProfileList()} is not empty.
+     */
     public function setSortBy(string $sortBy): self
     {
         $this->sortBy = $sortBy;
         return $this;
     }
 
+    /**
+     * Does not have any effect when {@see self::getProfileList()} is not empty.
+     */
     public function getSortByDirection(): string
     {
         return $this->sortByDirection;
     }
 
+    /**
+     * Does not have any effect when {@see self::getProfileList()} is not empty.
+     */
     public function setSortByDirection(string $sortByDirection): self
     {
         $this->sortByDirection = $sortByDirection;
         return $this;
     }
 
+    /**
+     * Does not have any effect when {@see self::getProfileList()} is not empty.
+     */
     public function getCurrentPage(): int
     {
         return $this->currentPage;
     }
 
+    /**
+     * Does not have any effect when {@see self::getProfileList()} is not empty.
+     */
     public function setCurrentPage(int $currentPage): self
     {
         $this->currentPage = $currentPage;
         return $this;
     }
 
+    /**
+     * Does not have any effect when {@see self::getProfileList()} is not empty.
+     */
     public function getAlphabetFilter(): string
     {
         return $this->alphabetFilter;
     }
 
+    /**
+     * Does not have any effect when {@see self::getProfileList()} is not empty.
+     */
     public function setAlphabetFilter(string $alphabetFilter): self
     {
         $this->alphabetFilter = $alphabetFilter;
         return $this;
     }
 
+    /**
+     * Overrules all other filter options when not empty string,
+     * except special settings:
+     *
+     * - {@see self::getFallbackForNonTranslated()}
+     * - {@see self::getStoragePages()}
+     */
     public function getProfileList(): string
     {
         return $this->profileList;
     }
 
+    /**
+     * Overrules all other filter options when not empty string,
+     * except special settings:
+     *
+     * - {@see self::getFallbackForNonTranslated()}
+     * - {@see self::getStoragePages()}
+     */
     public function setProfileList(string $profileList): self
     {
         $this->profileList = $profileList;
+        return $this;
+    }
+
+    /**
+     * Not usable for hydration or direct extbase request argument mapping,
+     * only to transport direct storage page selection within the DTO to the
+     * {@see ProfileRepository::findByDemand()} method.
+     */
+    public function getStoragePages(): string
+    {
+        return $this->storagePages;
+    }
+
+    /**
+     * Not usable for hydration or direct extbase request argument mapping,
+     * only to transport direct storage page selection within the DTO to the
+     * {@see ProfileRepository::findByDemand()} method.
+     */
+    public function setStoragePages(string $storagePages): ProfileDemand
+    {
+        $this->storagePages = $storagePages;
+        return $this;
+    }
+
+    /**
+     * Not usable for hydration or direct extbase request argument mapping,
+     * only to transport direct storage page selection within the DTO to the
+     * {@see ProfileRepository::findByDemand()} method.
+     */
+    public function getFallbackForNonTranslated(): int
+    {
+        return $this->fallbackForNonTranslated;
+    }
+
+    /**
+     * Not usable for hydration or direct extbase request argument mapping,
+     * only to transport direct storage page selection within the DTO to the
+     * {@see ProfileRepository::findByDemand()} method.
+     */
+    public function setFallbackForNonTranslated(int $fallbackForNonTranslated): ProfileDemand
+    {
+        $this->fallbackForNonTranslated = $fallbackForNonTranslated;
         return $this;
     }
 }


### PR DESCRIPTION
This change adds storage pages and plugin fallback enforce
option to the `ProfileDemand` implementation and commented
out to the `DemandInterface` with `@todo's` to make add'em
breaking with next major version.

`ProfileController::adoptSettings()` will adopt options to
the DemandObject if method exits, otherwise still setting
options directly to the `ProfileRepository` but triggering
deprecation now.

Classes implemented based on `DemandInterface` will trigger
E_USER_DEPRECATED passed to ProfileController::listAction()
or `ProfileRepository::findByDemand()` when follwing methods
are missing:

* DemandInterface::setStoragePages(string): self
* DemandInterface::getStoragePages(): string
* DemandInterface::setFallbackForNonTranslated(int): self
* DemandInterface::getFallbackForNonTranslated(): int

Default implementation `ProfileDemand` implements aforementioned
methods, matching commented method signatures of the interface.
