### PR TITLE
[BUGFIX] Ensure selected localized profiles are retrieved for list views

### DIFF
--- a/Classes/Domain/Repository/ProfileRepository.php
+++ b/Classes/Domain/Repository/ProfileRepository.php
@@ -112,6 +112,12 @@ class ProfileRepository extends Repository
         // Direct selected profiles make all other filters and orderings obsolete and is handled first.
         if ($demand->getProfileList() !== '') {
             $profileUidArray = GeneralUtility::intExplode(',', $demand->getProfileList(), true);
+            /**
+             * Selected profile uid's are default language id's and fails to retrieve the profiles for non default
+             * language's. Disable respecting sys_language helps, using defined overlay mode based on siteLanguage
+             * configuration OR custom `fallbackForNonTranslated` handling {@see self::applyDemandSettings()}.
+             */
+            $query->getQuerySettings()->setRespectSysLanguage(false);
             $query->matching($query->in('uid', $profileUidArray));
             return;
         }

--- a/Tests/Functional/Plugins/AcademicPersonsListAndDetailPluginTest.php
+++ b/Tests/Functional/Plugins/AcademicPersonsListAndDetailPluginTest.php
@@ -408,126 +408,117 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
 
     /**
      * @test
-     * @todo This is expected to work. Remove skipping test when fixing it.
      */
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrder(): void
     {
-        static::markTestSkipped('Expected to work, but does not. Skipped until fixed.');
-        //$this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles.csv');
-        //$this->setUpFrontendRootPageForTestCase();
-        //$this->writeSiteConfiguration(
-        //    'acme',
-        //    $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
-        //    [
-        //        $this->buildDefaultLanguageConfiguration('EN', '/'),
-        //        $this->buildLanguageConfiguration('DE', '/de/'),
-        //    ]
-        //);
-        //
-        //$requestContext = new InternalRequestContext();
-        //$request = new InternalRequest('https://www.acme.com/de/home');
-        //$response = $this->executeFrontendSubRequest($request, $requestContext);
-        //self::assertSame(200, $response->getStatusCode());
-        //
-        //$content = (string)$response->getBody();
-        //static::assertStringContainsString('<h2>Profilelist</h2>', $content);
-        //static::assertStringContainsString('#0(3): [DE] Horst Huber', $content);
-        //static::assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
-        //static::assertStringNotContainsString('[EN] Horst Huber', $content);
-        //static::assertStringNotContainsString('[EN] Max Müllermann', $content);
-    }
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/'),
+            ]
+        );
 
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/de/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(3): [DE] Horst Huber', $content);
+        static::assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
+        static::assertStringNotContainsString('[EN] Horst Huber', $content);
+        static::assertStringNotContainsString('[EN] Max Müllermann', $content);
+    }
 
     /**
      * @test
-     * @todo This is expected to work. Remove skipping test when fixing it.
      */
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeStrictWhenNotAllProfilesAreLocalized(): void
     {
-        static::markTestSkipped('Expected to work, but does not. Skipped until fixed.');
-        //$this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv');
-        //$this->setUpFrontendRootPageForTestCase();
-        //$this->writeSiteConfiguration(
-        //    'acme',
-        //    $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
-        //    [
-        //        $this->buildDefaultLanguageConfiguration('EN', '/'),
-        //        $this->buildLanguageConfiguration('DE', '/de/', [], 'strict'),
-        //    ]
-        //);
-        //
-        //$requestContext = new InternalRequestContext();
-        //$request = new InternalRequest('https://www.acme.com/de/home');
-        //$response = $this->executeFrontendSubRequest($request, $requestContext);
-        //self::assertSame(200, $response->getStatusCode());
-        //
-        //$content = (string)$response->getBody();
-        //static::assertStringContainsString('<h2>Profilelist</h2>', $content);
-        //static::assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
-        //static::assertStringNotContainsString('[EN] Horst Huber', $content);
-        //static::assertStringNotContainsString('[DE] Horst Huber', $content);
-        //static::assertStringNotContainsString('[EN] Max Müllermann', $content);
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', [], 'strict'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/de/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
+        static::assertStringNotContainsString('[EN] Horst Huber', $content);
+        static::assertStringNotContainsString('[DE] Horst Huber', $content);
+        static::assertStringNotContainsString('[EN] Max Müllermann', $content);
     }
 
     /**
      * @test
-     * @todo This is expected to work. Remove skipping test when fixing it.
      */
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeStrictWhenNotAllProfilesAreLocalizedButPluginFallbackSet(): void
     {
-        static::markTestSkipped('Expected to work, but does not. Skipped until fixed.');
-        //$this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv');
-        //$this->setUpFrontendRootPageForTestCase();
-        //$this->writeSiteConfiguration(
-        //    'acme',
-        //    $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
-        //    [
-        //        $this->buildDefaultLanguageConfiguration('EN', '/'),
-        //        $this->buildLanguageConfiguration('DE', '/de/'),
-        //    ]
-        //);
-        //
-        //$requestContext = new InternalRequestContext();
-        //$request = new InternalRequest('https://www.acme.com/de/home');
-        //$response = $this->executeFrontendSubRequest($request, $requestContext);
-        //self::assertSame(200, $response->getStatusCode());
-        //
-        //$content = (string)$response->getBody();
-        //static::assertStringContainsString('<h2>Profilelist</h2>', $content);
-        //static::assertStringContainsString('#0(3): [EN] Horst Huber', $content);
-        //static::assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
-        //static::assertStringNotContainsString('[DE] Horst Huber', $content);
-        //static::assertStringNotContainsString('[EN] Max Müllermann', $content);
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/de/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(3): [EN] Horst Huber', $content);
+        static::assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
+        static::assertStringNotContainsString('[DE] Horst Huber', $content);
+        static::assertStringNotContainsString('[EN] Max Müllermann', $content);
     }
 
     /**
      * @test
-     * @todo This is expected to work. Remove skipping test when fixing it.
      */
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeFallbackWhenNotAllProfilesAreLocalized(): void
     {
-        static::markTestSkipped('Expected to work, but does not. Skipped until fixed.');
-        //$this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv');
-        //$this->setUpFrontendRootPageForTestCase();
-        //$this->writeSiteConfiguration(
-        //    'acme',
-        //    $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
-        //    [
-        //        $this->buildDefaultLanguageConfiguration('EN', '/'),
-        //        $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'fallback'),
-        //    ]
-        //);
-        //
-        //$requestContext = new InternalRequestContext();
-        //$request = new InternalRequest('https://www.acme.com/de/home');
-        //$response = $this->executeFrontendSubRequest($request, $requestContext);
-        //self::assertSame(200, $response->getStatusCode());
-        //
-        //$content = (string)$response->getBody();
-        //static::assertStringContainsString('<h2>Profilelist</h2>', $content);
-        //static::assertStringContainsString('#0(3): [EN] Horst Huber', $content);
-        //static::assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
-        //static::assertStringNotContainsString('[DE] Horst Huber', $content);
-        //static::assertStringNotContainsString('[EN] Max Müllermann', $content);
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'fallback'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/de/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(3): [EN] Horst Huber', $content);
+        static::assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
+        static::assertStringNotContainsString('[DE] Horst Huber', $content);
+        static::assertStringNotContainsString('[EN] Max Müllermann', $content);
     }
 }

--- a/Tests/Functional/Plugins/AcademicPersonsListPluginTest.php
+++ b/Tests/Functional/Plugins/AcademicPersonsListPluginTest.php
@@ -304,125 +304,117 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
 
     /**
      * @test
-     * @todo This is expected to work. Remove skipping test when fixing it.
      */
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrder(): void
     {
-        static::markTestSkipped('Expected to work, but does not. Skipped until fixed.');
-        //$this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles.csv');
-        //$this->setUpFrontendRootPageForTestCase();
-        //$this->writeSiteConfiguration(
-        //    'acme',
-        //    $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
-        //    [
-        //        $this->buildDefaultLanguageConfiguration('EN', '/'),
-        //        $this->buildLanguageConfiguration('DE', '/de/'),
-        //    ]
-        //);
-        //
-        //$requestContext = new InternalRequestContext();
-        //$request = new InternalRequest('https://www.acme.com/de/home');
-        //$response = $this->executeFrontendSubRequest($request, $requestContext);
-        //self::assertSame(200, $response->getStatusCode());
-        //
-        //$content = (string)$response->getBody();
-        //static::assertStringContainsString('<h2>Profilelist</h2>', $content);
-        //static::assertStringContainsString('#0(3): [DE] Horst Huber', $content);
-        //static::assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
-        //static::assertStringNotContainsString('[EN] Horst Huber', $content);
-        //static::assertStringNotContainsString('[EN] Max Müllermann', $content);
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/de/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(3): [DE] Horst Huber', $content);
+        static::assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
+        static::assertStringNotContainsString('[EN] Horst Huber', $content);
+        static::assertStringNotContainsString('[EN] Max Müllermann', $content);
     }
 
     /**
      * @test
-     * @todo This is expected to work. Remove skipping test when fixing it.
      */
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeStrictWhenNotAllProfilesAreLocalized(): void
     {
-        static::markTestSkipped('Expected to work, but does not. Skipped until fixed.');
-        //$this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv');
-        //$this->setUpFrontendRootPageForTestCase();
-        //$this->writeSiteConfiguration(
-        //    'acme',
-        //    $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
-        //    [
-        //        $this->buildDefaultLanguageConfiguration('EN', '/'),
-        //        $this->buildLanguageConfiguration('DE', '/de/', [], 'strict'),
-        //    ]
-        //);
-        //
-        //$requestContext = new InternalRequestContext();
-        //$request = new InternalRequest('https://www.acme.com/de/home');
-        //$response = $this->executeFrontendSubRequest($request, $requestContext);
-        //self::assertSame(200, $response->getStatusCode());
-        //
-        //$content = (string)$response->getBody();
-        //static::assertStringContainsString('<h2>Profilelist</h2>', $content);
-        //static::assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
-        //static::assertStringNotContainsString('[EN] Horst Huber', $content);
-        //static::assertStringNotContainsString('[DE] Horst Huber', $content);
-        //static::assertStringNotContainsString('[EN] Max Müllermann', $content);
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', [], 'strict'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/de/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
+        static::assertStringNotContainsString('[EN] Horst Huber', $content);
+        static::assertStringNotContainsString('[DE] Horst Huber', $content);
+        static::assertStringNotContainsString('[EN] Max Müllermann', $content);
     }
 
     /**
      * @test
-     * @todo This is expected to work. Remove skipping test when fixing it.
      */
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeStrictWhenNotAllProfilesAreLocalizedButPluginFallbackSet(): void
     {
-        static::markTestSkipped('Expected to work, but does not. Skipped until fixed.');
-        //$this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv');
-        //$this->setUpFrontendRootPageForTestCase();
-        //$this->writeSiteConfiguration(
-        //    'acme',
-        //    $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
-        //    [
-        //        $this->buildDefaultLanguageConfiguration('EN', '/'),
-        //        $this->buildLanguageConfiguration('DE', '/de/'),
-        //    ]
-        //);
-        //
-        //$requestContext = new InternalRequestContext();
-        //$request = new InternalRequest('https://www.acme.com/de/home');
-        //$response = $this->executeFrontendSubRequest($request, $requestContext);
-        //self::assertSame(200, $response->getStatusCode());
-        //
-        //$content = (string)$response->getBody();
-        //static::assertStringContainsString('<h2>Profilelist</h2>', $content);
-        //static::assertStringContainsString('#0(3): [EN] Horst Huber', $content);
-        //static::assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
-        //static::assertStringNotContainsString('[DE] Horst Huber', $content);
-        //static::assertStringNotContainsString('[EN] Max Müllermann', $content);
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/de/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(3): [EN] Horst Huber', $content);
+        static::assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
+        static::assertStringNotContainsString('[DE] Horst Huber', $content);
+        static::assertStringNotContainsString('[EN] Max Müllermann', $content);
     }
 
     /**
      * @test
-     * @todo This is expected to work. Remove skipping test when fixing it.
      */
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeFallbackWhenNotAllProfilesAreLocalized(): void
     {
-        static::markTestSkipped('Expected to work, but does not. Skipped until fixed.');
-        //$this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv');
-        //$this->setUpFrontendRootPageForTestCase();
-        //$this->writeSiteConfiguration(
-        //    'acme',
-        //    $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
-        //    [
-        //        $this->buildDefaultLanguageConfiguration('EN', '/'),
-        //        $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'fallback'),
-        //    ]
-        //);
-        //
-        //$requestContext = new InternalRequestContext();
-        //$request = new InternalRequest('https://www.acme.com/de/home');
-        //$response = $this->executeFrontendSubRequest($request, $requestContext);
-        //self::assertSame(200, $response->getStatusCode());
-        //
-        //$content = (string)$response->getBody();
-        //static::assertStringContainsString('<h2>Profilelist</h2>', $content);
-        //static::assertStringContainsString('#0(3): [EN] Horst Huber', $content);
-        //static::assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
-        //static::assertStringNotContainsString('[DE] Horst Huber', $content);
-        //static::assertStringNotContainsString('[EN] Max Müllermann', $content);
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'fallback'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/de/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Profilelist</h2>', $content);
+        static::assertStringContainsString('#0(3): [EN] Horst Huber', $content);
+        static::assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
+        static::assertStringNotContainsString('[DE] Horst Huber', $content);
+        static::assertStringNotContainsString('[EN] Max Müllermann', $content);
     }
 }


### PR DESCRIPTION
The `list` and `list and detail` plugins have a flexform setting
to select a ordered list of profiles, which are saved as a list
of default language uid values despite they are localized or not,
which is the usual case and the requirement TYPO3 and Extbase is
build on.

Doing a casual extbase query to find records (models) based on the
requires to disable respecting the sys_language_uid and overlaying
records, based on the site language defined overlay setting along
with the additional enforcement option `FallbackForNonTranslated`.

This change ensures to set

```php
  $query->getQuerySettings()->setRespectSysLanguage(false);
```

when a list of selected profiles is given next to adding the
constraint (`IN()`) to ensure that localized profiles and
also  mixed localized profiles are retrieved in this case.

A couple of prepared functional tests are unskipped and the
commented code enabled covering that this issue is fixed.
