### PR TITLE
[TASK] Avoid errorprone `sed` to fetch `git tag content`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get comment
         id: get-comment
         run: |
-          readonly local comment=$(git tag -n10 -l ${{ env.version }} | sed "s/^[0-9.]*[ ]*//g")
+          readonly local comment="$( git tag -l ${{ env.version }} --format '%(contents)' )"
 
           if [[ -z "${comment// }" ]]; then
             echo "comment=Released version ${{ env.version }} of ${{ env.TYPO3_EXTENSION_KEY }}" >> $GITHUB_ENV


### PR DESCRIPTION
The publish workflow contains a step to extract the commit
message for the tag to use it as release message uploading
to TYPO3 Extension Repository using `tailor`.

Aforementioned step listed 10 lines per tag, filtered by
the version extracted within a previous step byed on git
`refs/tags/*` combining it with a sed command to remove
the version number on the first line to get the raw commit
message.

Let us break this down into peases. Following command

```shell
git tag -n10 -l 0.3.0
```

will display following output:

```shell
0.3.0   [BUGFIX] Fix condition for non translated ...
```

On this, `sed "s/^[0-9.]*[ ]*//g` is used to remove the
version prologue and ending with following text:

```
[BUGFIX] Fix condition for non translated fallback ...
```

This approach has two major flaws:

*  Displays only 10 lines for selected/filtered tag and
   leading to possible broken/incomplete release message.
*  Fails with an `sed` error (exit code) when the commit
   message is not only a one liner, but also contains an
   message block.

Last point relates to a tag commit message like following:

```
0.3.1           [TASK] Update extension version to 0.3.1

    Bumped the extension version from 0.2.1 to 0.3.1 in
    `ext_emconf.php`. This marks a new release, likely
    including updates or changes since the previous
    version.
```

This change replaces the sed filtering by use the format
option of the git tag command to formating the output to
display the tag content completly, directly omiting any
other output. Combined with the `-l <pattern>' filtering
on the specific tag this simplifies the implementation
while mitigated aforementioned issues, see:

```shell
$ git tag -l 0.3.1 --format '%(contents)'
[TASK] Update extension version to 0.3.1

Bumped the extension version from 0.2.1 to 0.3.1 in
`ext_emconf.php`. This marks a new release, likely
including updates or changes since the previous version.
```
