### PR TITLE
[TASK] Use spaces for indentation in all file types

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,8 +24,8 @@ indent_size = 4
 
 # HTML-Files / Fluid standalone template
 [*.html]
-indent_style = tab
-indent_size = 2
+indent_style = space
+indent_size = 4
 
 # JSON-Files
 [*.json]
@@ -35,7 +35,7 @@ indent_size = 4
 # ReST-Files
 [*.rst]
 indent_style = space
-indent_size = 3
+indent_size = 4
 
 # MD-Files
 [*.md]


### PR DESCRIPTION
Updated `.editorconfig` to standardize indentation
using spaces instead of tabs and adjusted indent
sizes for consistency, promoting cleaner and more
maintainable code formatting.

`*.json` is kept as `tab` indent_style to match
TYPO3 core development and usual adoption within
the TYPO3 ecosystem.
