### PR TITLE
[!!!][TASK] Remove project specific `his_id` and `his_parent_id` fields

### DIFF
--- a/Classes/Domain/Model/FunctionType.php
+++ b/Classes/Domain/Model/FunctionType.php
@@ -25,8 +25,6 @@ class FunctionType extends AbstractEntity
 
     protected string $functionNameFemale = '';
 
-    protected int $hisId = 0;
-
     public function setFunctionName(string $functionName): void
     {
         $this->functionName = $functionName;
@@ -55,15 +53,5 @@ class FunctionType extends AbstractEntity
     public function getFunctionNameFemale(): string
     {
         return $this->functionNameFemale;
-    }
-
-    public function setHisId(int $hisId): void
-    {
-        $this->hisId = $hisId;
-    }
-
-    public function getHisId(): int
-    {
-        return $this->hisId;
     }
 }

--- a/Classes/Domain/Model/OrganisationalUnit.php
+++ b/Classes/Domain/Model/OrganisationalUnit.php
@@ -37,10 +37,6 @@ class OrganisationalUnit extends AbstractEntity
 
     protected ?DateTime $validTo = null;
 
-    protected int $hisId = 0;
-
-    protected int $hisParentId = 0;
-
     /**
      * @var ObjectStorage<Contract>
      * @Lazy
@@ -121,26 +117,6 @@ class OrganisationalUnit extends AbstractEntity
     public function getValidTo(): ?DateTime
     {
         return $this->validTo;
-    }
-
-    public function setHisId(int $hisId): void
-    {
-        $this->hisId = $hisId;
-    }
-
-    public function getHisId(): int
-    {
-        return $this->hisId;
-    }
-
-    public function setHisParentId(int $hisParentId): void
-    {
-        $this->hisParentId = $hisParentId;
-    }
-
-    public function getHisParentId(): int
-    {
-        return $this->hisParentId;
     }
 
     /**

--- a/Configuration/TCA/tx_academicpersons_domain_model_function_type.php
+++ b/Configuration/TCA/tx_academicpersons_domain_model_function_type.php
@@ -75,11 +75,6 @@ return [
                 'type' => 'passthrough',
             ],
         ],
-        'his_id' => [
-            'config' => [
-                'type' => 'passthrough',
-            ],
-        ],
         'function_name' => [
             'label' => $ll('columns.function_name.label'),
             'config' => [

--- a/Configuration/TCA/tx_academicpersons_domain_model_organisational_unit.php
+++ b/Configuration/TCA/tx_academicpersons_domain_model_organisational_unit.php
@@ -75,11 +75,6 @@ return [
                 'type' => 'passthrough',
             ],
         ],
-        'his_id' => [
-            'config' => [
-                'type' => 'passthrough',
-            ],
-        ],
         'parent' => [
             'label' => $ll('columns.parent.label'),
             'l10n_mode' => 'exclude',

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -24,7 +24,6 @@ CREATE TABLE tx_academicpersons_domain_model_contract (
     function_type int(11) unsigned DEFAULT NULL,
     valid_from int(11) DEFAULT NULL,
     valid_to int(11) DEFAULT NULL,
-    his_id int(11) DEFAULT '0' NOT NULL,
 
     employee_type int(11) unsigned DEFAULT '0' NOT NULL,
     position varchar(255) DEFAULT '' NOT NULL,
@@ -54,7 +53,6 @@ CREATE TABLE tx_academicpersons_domain_model_function_type (
     function_name varchar(255) DEFAULT '' NOT NULL,
     function_name_male varchar(255) DEFAULT '' NOT NULL,
     function_name_female varchar(255) DEFAULT '' NOT NULL,
-    his_id int(11) DEFAULT '0' NOT NULL,
 );
 
 CREATE TABLE tx_academicpersons_domain_model_location (
@@ -67,10 +65,6 @@ CREATE TABLE tx_academicpersons_domain_model_organisational_unit (
     unique_name varchar(255) DEFAULT '' NOT NULL,
     display_text text,
     long_text text,
-    valid_from int(11) unsigned DEFAULT '0' NOT NULL,
-    valid_to int(11) unsigned DEFAULT '0' NOT NULL,
-    his_id int(11) DEFAULT '0' NOT NULL,
-    his_parent_id int(11) DEFAULT '0' NOT NULL,
     contracts int(11) unsigned DEFAULT '0' NOT NULL,
 );
 


### PR DESCRIPTION
The `his_id` on a couple of tables is a project
specific addition and not required in general,
and now removed from following tables:

* tx_academicpersons_domain_model_contract
* tx_academicpersons_domain_model_function_type
* tx_academicpersons_domain_model_organisational_unit
* tx_academicpersons_domain_model_location

This includes `TCA` and `ext_tables.sql` configuration
and cleaning the extbase models.

Note that `valid_from` and `valid_to` table column definition
is also removed for `tx_academicpersons_domain_model_location`
in the `ext_tables.sql` file, not having these field defined
in TCA or the extbase model anyway.

This change is technically breaking in case removed his_id and
his_parent_id properties or getter/setter has been used on the
model.
