### PR TITLE
[BUGFIX] Avoid undefined array key access error

### DIFF
--- a/Classes/Controller/ProfileController.php
+++ b/Classes/Controller/ProfileController.php
@@ -147,12 +147,12 @@ final class ProfileController extends ActionController
         $hasStoragePids = (
             is_array($contentObjectData)
             && !empty($contentObjectData['pages'])
-            && is_string($contentObjectData['data'])
+            && is_string($contentObjectData['pages'])
         );
         if (method_exists($demand, 'setStoragePages')) {
             if ($hasStoragePids) {
                 // @todo See ProfileRepository::applyDemandSettings().
-                $demand->setStoragePages($contentObjectData['data']);
+                $demand->setStoragePages($contentObjectData['pages']);
             }
         } else {
             trigger_error(


### PR DESCRIPTION
With 7b1ff68 the ProfileController has been
restructured and settings passed as part of
the demand object and checks tightened.

Sadly, the check has not been composed carefully
enough and also slipped through the review and
introduced an `undefined array key access` issue,
spamming error long in instances.

This change further tighten the checks and use
the correct keys for selected storage pages,
no longer spamming following issue:

```
PHP Warning: Undefined array key "data" in
vendor/fgtclb/academic-persons/Classes/Controller/ProfileController.php line 150
```
