### PR TITLE
[TASK] Add functional tests for selected profiles and contracts plugins

### DIFF
--- a/Tests/Functional/Fixtures/Extensions/test_plugin_templates/Resources/Private/Partials/SelectedContracts/ListItem.html
+++ b/Tests/Functional/Fixtures/Extensions/test_plugin_templates/Resources/Private/Partials/SelectedContracts/ListItem.html
@@ -1,0 +1,6 @@
+<html
+    data-namespace-typo3-fluid="true"
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+>
+    #{itemIterator.index}({contract.uid}): {contract.position}
+</html>

--- a/Tests/Functional/Fixtures/Extensions/test_plugin_templates/Resources/Private/Templates/Profile/SelectedContracts.html
+++ b/Tests/Functional/Fixtures/Extensions/test_plugin_templates/Resources/Private/Templates/Profile/SelectedContracts.html
@@ -1,0 +1,29 @@
+<html
+    data-namespace-typo3-fluid="true"
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+>
+    <h2>Selected Contracts</h2>
+    <f:if condition="{contracts}">
+        <f:then>
+            <ul>
+                <f:for
+                    each="{contracts}"
+                    as="contract"
+                    iteration="itemIterator"
+                >
+                    <f:render
+                        partial="SelectedContracts/ListItem"
+                        arguments="{
+                            contract: contract,
+                            settings: settings,
+                            itemIterator: itemIterator
+                        }"
+                    />
+                </f:for>
+            </ul>
+        </f:then>
+        <f:else>
+            <p>No contracts found.</p>
+        </f:else>
+    </f:if>
+</html>

--- a/Tests/Functional/Fixtures/Extensions/test_plugin_templates/Resources/Private/Templates/Profile/SelectedProfiles.html
+++ b/Tests/Functional/Fixtures/Extensions/test_plugin_templates/Resources/Private/Templates/Profile/SelectedProfiles.html
@@ -1,0 +1,29 @@
+<html
+    data-namespace-typo3-fluid="true"
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+>
+    <h2>Selected Profiles</h2>
+    <f:if condition="{profiles}">
+        <f:then>
+            <ul>
+                <f:for
+                    each="{profiles}"
+                    as="profile"
+                    iteration="itemIterator"
+                >
+                    <f:render
+                        partial="List/ListItem"
+                        arguments="{
+                            profile: profile,
+                            settings: settings,
+                            itemIterator: itemIterator
+                        }"
+                    />
+                </f:for>
+            </ul>
+        </f:then>
+        <f:else>
+            <p>No profiles found.</p>
+        </f:else>
+    </f:if>
+</html>

--- a/Tests/Functional/Plugins/AcademicPersonsSelectedContractsPluginTest.php
+++ b/Tests/Functional/Plugins/AcademicPersonsSelectedContractsPluginTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fgtclb\AcademicPersons\Tests\Functional\Plugins;
+
+use Fgtclb\AcademicPersons\Tests\Functional\Fixtures\Trait\SiteBasedTestTrait;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+final class AcademicPersonsSelectedContractsPluginTest extends FunctionalTestCase
+{
+    use SiteBasedTestTrait;
+
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-fluid-styled-content',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'georgringer/numbered-pagination',
+        'fgtclb/academic-persons',
+        'tests/plugin-templates',
+    ];
+
+    protected array $configurationToUseInTestInstance = [
+        'SYS' => [
+            'encryptionKey' => '4408d27a916d51e624b69af3554f516dbab61037a9f7b9fd6f81b4d3bedeccb6',
+            'features' => [
+                'subrequestPageErrors' => true,
+            ],
+        ],
+        'FE' => [
+            'cacheHash' => [
+                'requireCacheHashPresenceParameters' => ['value', 'testing[value]', 'tx_testing_link[value]'],
+                'excludedParameters' => ['L', 'tx_testing_link[excludedValue]'],
+                'enforceValidation' => true,
+            ],
+            'debug' => false,
+        ],
+        'SC_OPTIONS' => [
+            'Core/TypoScript/TemplateService' => [
+                'runThroughTemplatesPostProcessing' => [
+                    'FunctionalTest' => \TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Hook\TypoScriptInstructionModifier::class . '->apply',
+                ],
+            ],
+        ],
+    ];
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
+        'DE' => ['id' => 1, 'title' => 'Deutsch', 'locale' => 'de_DE.UTF8', 'iso' => 'de', 'hrefLang' => 'de-DE', 'direction' => ''],
+        'FR' => ['id' => 2, 'title' => 'French', 'locale' => 'fr_FR.UTF8', 'iso' => 'fr', 'hrefLang' => 'fr-FR', 'direction' => ''],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
+        parent::tearDown();
+    }
+
+    private function setUpFrontendRootPageForTestCase(): void
+    {
+        $this->setUpFrontendRootPage(
+            1,
+            [
+                'constants' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_persons/Configuration/TypoScript/constants.typoscript',
+                    'EXT:test_plugin_templates/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_persons/Tests/Functional/Plugins/Fixtures/TypoScript/Constants/PluginConfiguration.typoscript',
+                ],
+                'setup' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_persons/Configuration/TypoScript/setup.typoscript',
+                    'EXT:test_plugin_templates/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_persons/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript',
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function defaultLanguageOnly_allContractsSelected(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedContractsPlugin/defaultLanguageOnly_allContractsSelected.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Selected Contracts</h2>', $content);
+        static::assertStringContainsString('#0(2): Manager', $content);
+        static::assertStringContainsString('#1(1): Worker', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function defaultLanguageOnly_oneContractSelected(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedContractsPlugin/defaultLanguageOnly_oneContractSelected.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Selected Contracts</h2>', $content);
+        static::assertStringContainsString('#0(2): Manager', $content);
+        static::assertStringNotContainsString('Worker', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function fullyLocalized_allContractsSelected_allContractsLocalized(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedContractsPlugin/fullyLocalized_allContractsSelected_allContractsLocalized.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                //$this->buildLanguageConfiguration('DE', '/de/'),
+                $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'content_fallback'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/de/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Selected Contracts</h2>', $content);
+        static::assertStringContainsString('#0(3): [DE] Manager', $content);
+        static::assertStringContainsString('#1(1): [DE] Arbeiter', $content);
+        static::assertStringNotContainsString('[EN] Manager', $content);
+        static::assertStringNotContainsString('[EN] Worker', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function fullyLocalized_allContractsSelected_notAllContractsLocalized_strictMode(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedContractsPlugin/fullyLocalized_allContractsSelected_notAllContractsLocalized.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', [], 'strict'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/de/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Selected Contracts</h2>', $content);
+        static::assertStringContainsString('#0(3): [EN] Manager', $content);
+        static::assertStringContainsString('#1(1): [DE] Arbeiter', $content);
+        static::assertStringNotContainsString('[DE] Manager', $content);
+        static::assertStringNotContainsString('[EN] Worker', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function fullyLocalized_SelectedContracts_notAllContractsLocalized_fallbackMode(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedContractsPlugin/fullyLocalized_allContractsSelected_notAllContractsLocalized.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'content_fallback'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/de/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Selected Contracts</h2>', $content);
+        static::assertStringContainsString('#0(3): [EN] Manager', $content);
+        static::assertStringContainsString('#1(1): [DE] Arbeiter', $content);
+        static::assertStringNotContainsString('[DE] Manager', $content);
+        static::assertStringNotContainsString('[EN] Worker', $content);
+    }
+}

--- a/Tests/Functional/Plugins/AcademicPersonsSelectedProfilesPluginTest.php
+++ b/Tests/Functional/Plugins/AcademicPersonsSelectedProfilesPluginTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fgtclb\AcademicPersons\Tests\Functional\Plugins;
+
+use Fgtclb\AcademicPersons\Tests\Functional\Fixtures\Trait\SiteBasedTestTrait;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+final class AcademicPersonsSelectedProfilesPluginTest extends FunctionalTestCase
+{
+    use SiteBasedTestTrait;
+
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-fluid-styled-content',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'georgringer/numbered-pagination',
+        'fgtclb/academic-persons',
+        'tests/plugin-templates',
+    ];
+
+    protected array $configurationToUseInTestInstance = [
+        'SYS' => [
+            'encryptionKey' => '4408d27a916d51e624b69af3554f516dbab61037a9f7b9fd6f81b4d3bedeccb6',
+            'features' => [
+                'subrequestPageErrors' => true,
+            ],
+        ],
+        'FE' => [
+            'cacheHash' => [
+                'requireCacheHashPresenceParameters' => ['value', 'testing[value]', 'tx_testing_link[value]'],
+                'excludedParameters' => ['L', 'tx_testing_link[excludedValue]'],
+                'enforceValidation' => true,
+            ],
+            'debug' => false,
+        ],
+        'SC_OPTIONS' => [
+            'Core/TypoScript/TemplateService' => [
+                'runThroughTemplatesPostProcessing' => [
+                    'FunctionalTest' => \TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Hook\TypoScriptInstructionModifier::class . '->apply',
+                ],
+            ],
+        ],
+    ];
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
+        'DE' => ['id' => 1, 'title' => 'Deutsch', 'locale' => 'de_DE.UTF8', 'iso' => 'de', 'hrefLang' => 'de-DE', 'direction' => ''],
+        'FR' => ['id' => 2, 'title' => 'French', 'locale' => 'fr_FR.UTF8', 'iso' => 'fr', 'hrefLang' => 'fr-FR', 'direction' => ''],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
+        parent::tearDown();
+    }
+
+    private function setUpFrontendRootPageForTestCase(): void
+    {
+        $this->setUpFrontendRootPage(
+            1,
+            [
+                'constants' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_persons/Configuration/TypoScript/constants.typoscript',
+                    'EXT:test_plugin_templates/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_persons/Tests/Functional/Plugins/Fixtures/TypoScript/Constants/PluginConfiguration.typoscript',
+                ],
+                'setup' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_persons/Configuration/TypoScript/setup.typoscript',
+                    'EXT:test_plugin_templates/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_persons/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript',
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function defaultLanguageOnly_allProfilesSelected(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedProfilesPlugin/defaultLanguageOnly_allProfilesSelected.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Selected Profiles</h2>', $content);
+        static::assertStringContainsString('#0(2): Horst Huber', $content);
+        static::assertStringContainsString('#1(1): Max Müllermann', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function defaultLanguageOnly_oneProfileSelected(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedProfilesPlugin/defaultLanguageOnly_oneProfileSelected.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Selected Profiles</h2>', $content);
+        static::assertStringContainsString('#0(2): Horst Huber', $content);
+        static::assertStringNotContainsString('Max Müllermann', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function fullyLocalized_allProfilesSelected_allProfilesLocalized(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedProfilesPlugin/fullyLocalized_allProfilesSelected_allProfilesLocalized.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                //$this->buildLanguageConfiguration('DE', '/de/'),
+                $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'content_fallback'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/de/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Selected Profiles</h2>', $content);
+        static::assertStringContainsString('#0(3): [DE] Horst Huber', $content);
+        static::assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
+        static::assertStringNotContainsString('[EN] Horst Huber', $content);
+        static::assertStringNotContainsString('[EN] Max Müllermann', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function fullyLocalized_allProfilesSelected_notAllProfilesLocalized_strictMode(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedProfilesPlugin/fullyLocalized_allProfilesSelected_notAllProfilesLocalized.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', [], 'strict'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/de/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Selected Profiles</h2>', $content);
+        static::assertStringContainsString('#0(3): [EN] Horst Huber', $content);
+        static::assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
+        static::assertStringNotContainsString('[DE] Horst Huber', $content);
+        static::assertStringNotContainsString('[EN] Max Müllermann', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackMode(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedProfilesPlugin/fullyLocalized_allProfilesSelected_notAllProfilesLocalized.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            'acme',
+            $this->buildSiteConfiguration(1, 'https://www.acme.com/'),
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'content_fallback'),
+            ]
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/de/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        static::assertStringContainsString('<h2>Selected Profiles</h2>', $content);
+        static::assertStringContainsString('#0(3): [EN] Horst Huber', $content);
+        static::assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
+        static::assertStringNotContainsString('[DE] Horst Huber', $content);
+        static::assertStringNotContainsString('[EN] Max Müllermann', $content);
+    }
+}

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedContractsPlugin/defaultLanguageOnly_allContractsSelected.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedContractsPlugin/defaultLanguageOnly_allContractsSelected.csv
@@ -1,0 +1,16 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,2,0,0,0,0,"list","academicpersons_selectedcontracts","Contracts","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedContracts""><value index=""vDEF"">2,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"Horst","Huber","horst-huber"
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","profile","position","location"
+,1,100,0,0,0,0,1,"Worker",0
+,2,100,0,0,0,0,2,"Manager",0

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedContractsPlugin/defaultLanguageOnly_oneContractSelected.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedContractsPlugin/defaultLanguageOnly_oneContractSelected.csv
@@ -1,0 +1,16 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,2,0,0,0,0,"list","academicpersons_selectedcontracts","Contracts","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedContracts""><value index=""vDEF"">2</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"Horst","Huber","horst-huber"
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","profile","position","location"
+,1,100,0,0,0,0,1,"Worker",0
+,2,100,0,0,0,0,2,"Manager",0

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedContractsPlugin/fullyLocalized_allContractsSelected_allContractsLocalized.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedContractsPlugin/fullyLocalized_allContractsSelected_allContractsLocalized.csv
@@ -1,0 +1,24 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root (EN)"
+,2,0,1,0,0,1,1,0,"/","Site Root (DE)"
+,3,1,1,0,0,0,0,0,"/home","Home (EN)"
+,4,1,1,0,0,1,3,0,"/home","Home (DE)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,3,0,0,0,0,"list","academicpersons_selectedcontracts","Contracts","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedContracts""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"list","academicpersons_selectedcontracts","Contracts","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedContracts""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"
+,2,100,0,0,1,1,"[DE] Max","Müllermann","max-muellermann"
+,3,100,0,0,0,0,"[EN] Horst","Huber","horst-huber"
+,4,100,0,0,1,3,"[DE] Horst","Huber","horst-huber"
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","profile","position","location"
+,1,100,0,0,0,0,1,"[EN] Worker",0
+,2,100,0,0,1,1,2,"[DE] Arbeiter",0
+,3,100,0,0,0,0,3,"[EN] Manager",0
+,4,100,0,0,1,3,4,"[DE] Manager",0

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedContractsPlugin/fullyLocalized_allContractsSelected_notAllContractsLocalized.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedContractsPlugin/fullyLocalized_allContractsSelected_notAllContractsLocalized.csv
@@ -1,0 +1,22 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root (EN)"
+,2,0,1,0,0,1,1,0,"/","Site Root (DE)"
+,3,1,1,0,0,0,0,0,"/home","Home (EN)"
+,4,1,1,0,0,1,3,0,"/home","Home (DE)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,3,0,0,0,0,"list","academicpersons_selectedcontracts","Contracts","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedContracts""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"list","academicpersons_selectedcontracts","Contracts","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedContracts""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"
+,2,100,0,0,1,1,"[DE] Max","Müllermann","max-muellermann"
+,3,100,0,0,0,0,"[EN] Horst","Huber","horst-huber"
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","profile","position","location"
+,1,100,0,0,0,0,1,"[EN] Worker",0
+,2,100,0,0,1,1,2,"[DE] Arbeiter",0
+,3,100,0,0,0,0,3,"[EN] Manager",0

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedProfilesPlugin/defaultLanguageOnly_allProfilesSelected.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedProfilesPlugin/defaultLanguageOnly_allProfilesSelected.csv
@@ -1,0 +1,12 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,2,0,0,0,0,"list","academicpersons_selectedprofiles","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedProfiles""><value index=""vDEF"">2,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"Horst","Huber","horst-huber"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedProfilesPlugin/defaultLanguageOnly_oneProfileSelected.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedProfilesPlugin/defaultLanguageOnly_oneProfileSelected.csv
@@ -1,0 +1,12 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,2,0,0,0,0,"list","academicpersons_selectedprofiles","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedProfiles""><value index=""vDEF"">2</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"Horst","Huber","horst-huber"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedProfilesPlugin/fullyLocalized_allProfilesSelected_allProfilesLocalized.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedProfilesPlugin/fullyLocalized_allProfilesSelected_allProfilesLocalized.csv
@@ -1,0 +1,18 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root (EN)"
+,2,0,1,0,0,1,1,0,"/","Site Root (DE)"
+,3,1,1,0,0,0,0,0,"/home","Home (EN)"
+,4,1,1,0,0,1,3,0,"/home","Home (DE)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,3,0,0,0,0,"list","academicpersons_selectedprofiles","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedProfiles""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"list","academicpersons_selectedprofiles","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedProfiles""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"
+,2,100,0,0,1,1,"[DE] Max","Müllermann","max-muellermann"
+,3,100,0,0,0,0,"[EN] Horst","Huber","horst-huber"
+,4,100,0,0,1,3,"[DE] Horst","Huber","horst-huber"

--- a/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedProfilesPlugin/fullyLocalized_allProfilesSelected_notAllProfilesLocalized.csv
+++ b/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedProfilesPlugin/fullyLocalized_allProfilesSelected_notAllProfilesLocalized.csv
@@ -1,0 +1,17 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root (EN)"
+,2,0,1,0,0,1,1,0,"/","Site Root (DE)"
+,3,1,1,0,0,0,0,0,"/home","Home (EN)"
+,4,1,1,0,0,1,3,0,"/home","Home (DE)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,3,0,0,0,0,"list","academicpersons_selectedprofiles","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedProfiles""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"list","academicpersons_selectedprofiles","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedProfiles""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"
+,2,100,0,0,1,1,"[DE] Max","Müllermann","max-muellermann"
+,3,100,0,0,0,0,"[EN] Horst","Huber","horst-huber"

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -2,8 +2,8 @@ CREATE TABLE tx_academicpersons_domain_model_address (
     contract int(11) unsigned DEFAULT '0' NOT NULL,
     type varchar(40) DEFAULT '' NOT NULL,
 
-		employee_type int(11) unsigned DEFAULT '0' NOT NULL,
-		organisational_unit int(11) unsigned DEFAULT NULL,
+    employee_type int(11) unsigned DEFAULT '0' NOT NULL,
+    organisational_unit int(11) unsigned DEFAULT NULL,
     function_type int(11) unsigned DEFAULT NULL,
 
     street varchar(255) DEFAULT '' NOT NULL,


### PR DESCRIPTION
Two new plugins has been introduced recently [1]   
without some test coverage for the new plugins.

Both of them are sensitive to the same technical
issue regarding site language configuration and
fallback mode like the selected profiles for the
`listAndDetail` and `list` plugin, which had been
fixed recently and covered by tests. [2][3]

During the review the sensitive part has been
directly addressed and are now covered with
equaliant tests to cover the new plugins in
the same way.

[1] https://github.com/fgtclb/academic-persons/pull/53
[2] https://github.com/fgtclb/academic-persons/commit/b68cb13f9cb37022f8fa9d89ac78b549ca7e3a70
[3] https://github.com/fgtclb/academic-persons/commit/c595780221eb62530b9023be04fba81e48972ea1
