### PR TITLE
[TASK] Use curl upload as tailor fallback and detect extension-key

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,6 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     env:
-      TYPO3_EXTENSION_KEY: ${{ secrets.TYPO3_EXTENSION_KEY }}
       TYPO3_API_TOKEN: ${{ secrets.TYPO3_API_TOKEN }}
     permissions:
       contents: write
@@ -28,6 +27,10 @@ jobs:
       - name: Get version
         id: get-version
         run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+
+      - name: Determine extension key
+        id: get-extension-key
+        run: echo "DETECTED_EXTENSION_KEY=$(cat composer.json | jq -r '.extra."typo3/cms"."extension-key"' )" >> "$GITHUB_ENV"
 
       - name: Get comment
         id: get-comment
@@ -73,17 +76,33 @@ jobs:
           body: "${{ env.releaseCommentPrependBody }}"
           generate_release_notes: true
           files: |
-            tailor-version-artefact/${{ env.TYPO3_EXTENSION_KEY }}_${{ env.version }}.zip
+            tailor-version-artefact/${{ env.DETECTED_EXTENSION_KEY }}_${{ env.version }}.zip
             LICENSE
           fail_on_unmatched_files: true
 
       # @todo Currently an issue exists with the TYPO3 Extension Repository (TER) tailor based uploads, which seems to
-      #       be WAF related and the T3O TER Team working on. Allow this step to fail (continue on error) for now until
-      #       issues has been sorted out.
-      #       https://github.com/TYPO3/tailor/issues/82
+      # @todo be WAF related and the T3O TER Team working on. As intermediate solution fallback to curl based upload.
+      # @todo https://github.com/TYPO3/tailor/issues/82
       - name: Publish to TER
-        # @todo Remove `continue-on-error` after upload with tailor has been fixed.
-        continue-on-error: true
         run: |
+          exitCode=0
           php ~/.composer/vendor/bin/tailor ter:publish --comment "${{ env.terReleaseNotes }}" ${{ env.version }} \
-            --artefact=tailor-version-artefact/${{ env.TYPO3_EXTENSION_KEY }}_${{ env.version }}.zip
+            --artefact=tailor-version-artefact/${{ env.DETECTED_EXTENSION_KEY }}_${{ env.version }}.zip
+          exitCode="$?"
+          if [[ "${exitCode}" -ne 0 ]]; then
+            echo '>> Uploading to TYPO3 Extension Repository using "tailor" failed. Try using curl now.'
+            curl --location 'https://extensions.typo3.org/api/v1/extension/${{ env.DETECTED_EXTENSION_KEY }}/${{ env.version }}' \
+              --header 'Authorization: Bearer ${{ secrets.TYPO3_API_TOKEN }}' \
+              --form 'gplCompliant="1"' \
+              --form 'description="${{ env.terReleaseNotes }}"' \
+              --form 'file=@"tailor-version-artefact/${{ env.DETECTED_EXTENSION_KEY }}_${{ env.version }}.zip"'
+            exitCode="$?"
+            if [[ "${exitCode}" -ne 0 ]]; then
+              echo '>> Uploading to TYPO3 Extension Repository using "curl" failed.'
+            else
+              echo '>> Uploading to TYPO3 Extension Repository using "curl" succeeded.'
+            fi
+          else
+            echo '>> Uploading to TYPO3 Extension Repository using "tailor" succeeded.'
+          fi
+          exit ${exitCode}


### PR DESCRIPTION
This change modifies the GitHub publish workflow slightly,
detecting the extension key by reading it from the root
`composer.json` file in a preparation step.

The last step uploading the created upload artifact using
tailor is extended to use curl as fallback in case tailor
based upload failes, which currently is the case due to
known issues in the extension repository hosting and WAF
related to TYPO3 core version update last year.
