### PR TITLE
[BUGFIX] Set correct labels for EXT:academic_persons

### DIFF
--- a/Configuration/TCA/tx_academicpersons_domain_model_contract.php
+++ b/Configuration/TCA/tx_academicpersons_domain_model_contract.php
@@ -84,6 +84,7 @@ return [
             ],
         ],
         'profile' => [
+            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.ctrl.label',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',

--- a/Configuration/TCA/tx_academicpersons_domain_model_organisational_unit.php
+++ b/Configuration/TCA/tx_academicpersons_domain_model_organisational_unit.php
@@ -138,7 +138,7 @@ return [
             ],
         ],
         'contracts' => [
-            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_organisational_unit.columns.contracts.label',
+            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.contracts.label',
             'exclude' => true,
             'config' => [
                 'type' => 'inline',


### PR DESCRIPTION
The label `LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_organisational_unit.columns.contracts.label` does not exist.